### PR TITLE
Fixes #64

### DIFF
--- a/tests/integration/test_controllers.py
+++ b/tests/integration/test_controllers.py
@@ -176,6 +176,39 @@ class TestMS1Controller:
         check_mzML(env, OUT_DIR, filename)
         
 
+class TestTopNControllerSpectra:
+    """
+    Tests the Top-N controller that does standard DDA Top-N fragmentation scans with the simulated mass spec class.
+    Fragment spectra are generated via the "spectra" method
+    """
+
+    def test_TopN_controller_with_simulated_chems(self, fragscan_dataset_spectra, fragscan_ps):
+        logger.info('Testing Top-N controller with simulated chemicals -- no noise')
+        assert len(fragscan_dataset_spectra) == N_CHEMS
+
+        isolation_width = 1
+        N = 10
+        rt_tol = 15
+        mz_tol = 10
+        ionisation_mode = POSITIVE
+
+        # create a simulated mass spec without noise and Top-N controller
+        mass_spec = IndependentMassSpectrometer(ionisation_mode, fragscan_dataset_spectra, fragscan_ps)
+        controller = TopNController(ionisation_mode, N, isolation_width, mz_tol, rt_tol, MIN_MS1_INTENSITY)
+        min_bound, max_bound = get_rt_bounds(fragscan_dataset_spectra, CENTRE_RANGE)
+
+        # create an environment to run both the mass spec and controller
+        env = Environment(mass_spec, controller, min_bound, max_bound, progress_bar=True)
+        run_environment(env)
+
+        # check that there is at least one non-empty MS2 scan
+        check_non_empty_MS2(controller)
+
+        filename = 'topN_controller_simulated_chems_no_noise_spectra.mzML'
+        check_mzML(env, OUT_DIR, filename)
+
+
+
 class TestTopNController:
     """
     Tests the Top-N controller that does standard DDA Top-N fragmentation scans with the simulated mass spec class.

--- a/vimms/Chemicals.py
+++ b/vimms/Chemicals.py
@@ -384,7 +384,6 @@ class ChemicalCreator(object):
 
         spectra = self.peak_sampler.get_ms2_spectra()[0]
         kids = []
-        return kids
         intensity_props = self._get_msn_proportions(None, None, spectra.intensities)
         parent_mass_prop = self.peak_sampler.get_parent_intensity_proportion()
         for i in range(len(spectra.mzs)):


### PR DESCRIPTION
- Removed early return statement in `_get_children_spectra`
- Spectra now include peaks
- Added a test class `TestTopNControllerSpectra` to test this
- Test passes
- Note that this does not confirm the correctness of these spectra, or their intensities.

Fixes #64 