### PR TITLE
Restructured noise classes

### DIFF
--- a/tests/integration/test_controllers.py
+++ b/tests/integration/test_controllers.py
@@ -13,7 +13,7 @@ from vimms.Controller.fullscan import SimpleMs1Controller
 from vimms.Common import *
 from vimms.Environment import Environment
 from vimms.MassSpec import IndependentMassSpectrometer
-from vimms.Noise import GaussianPeakNoise
+from vimms.Noise import *
 
 ### define some useful constants ###
 
@@ -250,8 +250,9 @@ class TestTopNController:
         ionisation_mode = POSITIVE
 
         # create a simulated mass spec with noise and Top-N controller
-        peak_noise = GaussianPeakNoise(0.1, 1000)
-        mass_spec = IndependentMassSpectrometer(ionisation_mode, fragscan_dataset_peaks, fragscan_ps, peak_noise=peak_noise)
+        mz_noise = GaussianPeakNoise(0.1)
+        intensity_noise = GaussianPeakNoise(1000.)
+        mass_spec = IndependentMassSpectrometer(ionisation_mode, fragscan_dataset_peaks, fragscan_ps, mz_noise=mz_noise, intensity_noise=intensity_noise)
         controller = TopNController(ionisation_mode, N, isolation_width, mz_tol, rt_tol, MIN_MS1_INTENSITY)
         min_bound, max_bound = get_rt_bounds(fragscan_dataset_peaks, CENTRE_RANGE)
 
@@ -664,8 +665,9 @@ class TestDIAControllers:
 
         # create a simulated mass spec with noise and Top-N controller
         logger.info('With noise')
-        peak_noise = GaussianPeakNoise(0.1, 1000)
-        mass_spec = IndependentMassSpectrometer(ionisation_mode, fragscan_dataset_peaks, fragscan_ps, scan_duration_dict = scan_time_dict, peak_noise=peak_noise)
+        mz_noise = GaussianPeakNoiseLevelSpecific({2:0.01})
+        intensity_noise = GaussianPeakNoiseLevelSpecific({2:1000.})
+        mass_spec = IndependentMassSpectrometer(ionisation_mode, fragscan_dataset_peaks, fragscan_ps, scan_duration_dict = scan_time_dict, mz_noise=mz_noise, intensity_noise=intensity_noise)
         controller = AIF(min_mz,max_mz)
 
         # create an environment to run both the mass spec and controller

--- a/tests/integration/test_controllers.py
+++ b/tests/integration/test_controllers.py
@@ -176,6 +176,39 @@ class TestMS1Controller:
         check_mzML(env, OUT_DIR, filename)
         
 
+class TestTopNControllerSpectra:
+    """
+    Tests the Top-N controller that does standard DDA Top-N fragmentation scans with the simulated mass spec class.
+    Fragment spectra are generated via the "spectra" method
+    """
+
+    def test_TopN_controller_with_simulated_chems(self, fragscan_dataset_spectra, fragscan_ps):
+        logger.info('Testing Top-N controller with simulated chemicals -- no noise')
+        assert len(fragscan_dataset_spectra) == N_CHEMS
+
+        isolation_width = 1
+        N = 10
+        rt_tol = 15
+        mz_tol = 10
+        ionisation_mode = POSITIVE
+
+        # create a simulated mass spec without noise and Top-N controller
+        mass_spec = IndependentMassSpectrometer(ionisation_mode, fragscan_dataset_spectra, fragscan_ps)
+        controller = TopNController(ionisation_mode, N, isolation_width, mz_tol, rt_tol, MIN_MS1_INTENSITY)
+        min_bound, max_bound = get_rt_bounds(fragscan_dataset_spectra, CENTRE_RANGE)
+
+        # create an environment to run both the mass spec and controller
+        env = Environment(mass_spec, controller, min_bound, max_bound, progress_bar=True)
+        run_environment(env)
+
+        # check that there is at least one non-empty MS2 scan
+        check_non_empty_MS2(controller)
+
+        filename = 'topN_controller_simulated_chems_no_noise_spectra.mzML'
+        check_mzML(env, OUT_DIR, filename)
+
+
+
 class TestTopNController:
     """
     Tests the Top-N controller that does standard DDA Top-N fragmentation scans with the simulated mass spec class.

--- a/vimms/Chemicals.py
+++ b/vimms/Chemicals.py
@@ -384,7 +384,6 @@ class ChemicalCreator(object):
 
         spectra = self.peak_sampler.get_ms2_spectra()[0]
         kids = []
-        return kids
         intensity_props = self._get_msn_proportions(None, None, spectra.intensities)
         parent_mass_prop = self.peak_sampler.get_parent_intensity_proportion()
         for i in range(len(spectra.mzs)):

--- a/vimms/MassSpec.py
+++ b/vimms/MassSpec.py
@@ -232,8 +232,9 @@ class IndependentMassSpectrometer(object):
     ACQUISITION_STREAM_CLOSED = 'AcquisitionStreamClosing'
     STATE_CHANGED = 'StateChanged'
 
-    def __init__(self, ionisation_mode, chemicals, peak_sampler, peak_noise=None,
-                 isolation_transition_window='rectangular', isolation_transition_window_params=None, scan_duration_dict = DEFAULT_SCAN_TIME_DICT):
+    def __init__(self, ionisation_mode, chemicals, peak_sampler, mz_noise=None, intensity_noise=None,
+                 isolation_transition_window='rectangular', isolation_transition_window_params=None, 
+                 scan_duration_dict = DEFAULT_SCAN_TIME_DICT):
         """
         Creates a mass spec object.
         :param ionisation_mode: POSITIVE or NEGATIVE
@@ -277,9 +278,12 @@ class IndependentMassSpectrometer(object):
         self.current_DEW = 0
 
         # whether to add noise to the generated peaks, the default is no noise
-        self.peak_noise = peak_noise
-        if self.peak_noise is None:
-            self.peak_noise = NoPeakNoise()
+        self.mz_noise = mz_noise
+        self.intensity_noise = intensity_noise
+        if self.mz_noise is None:
+            self.mz_noise = NoPeakNoise()
+        if self.intensity_noise is None:
+            self.intensity_noise = NoPeakNoise()
 
         self.fragmentation_events = []  # which chemicals produce which peaks
 
@@ -574,18 +578,6 @@ class IndependentMassSpectrometer(object):
         idx = np.nonzero(rtmin_check & rtmax_check)[0]
         return idx
 
-    def _get_all_mz_peaks_noisy(self, chemical, query_rt, ms_level, isolation_windows):
-        mz_peaks = self._get_all_mz_peaks(chemical, query_rt, ms_level, isolation_windows)
-        if self.peak_sampler is None:
-            return mz_peaks
-        if mz_peaks is not None:
-            noisy_mz_peaks = [(mz_peaks[i][0], self.peak_sampler.get_msn_noisy_intensity(mz_peaks[i][1], ms_level)) for
-                              i in range(len(mz_peaks))]
-        else:
-            noisy_mz_peaks = []
-        noisy_mz_peaks += self.peak_sampler.get_noise_sample()
-        return noisy_mz_peaks
-
     def _get_all_mz_peaks(self, chemical, query_rt, ms_level, isolation_windows):
         # check if the chemical RT matches the current query RT
         if not self._rt_match(chemical, query_rt):
@@ -606,8 +598,8 @@ class IndependentMassSpectrometer(object):
         noisy_mz_peaks = []
         for i in range(len(mz_peaks)):
             original_mz, original_intensity = mz_peaks[i]
-            noisy_mz = self.peak_noise.get_mz(original_mz, query_rt, original_intensity, ms_level)
-            noisy_intensity = self.peak_noise.get_intensity(original_mz, query_rt, original_intensity, ms_level)
+            noisy_mz = self.mz_noise.get(original_mz, ms_level)
+            noisy_intensity = self.intensity_noise.get(original_intensity, ms_level)
             noisy_mz_peaks.append((noisy_mz, noisy_intensity))
         return noisy_mz_peaks
 

--- a/vimms/Noise.py
+++ b/vimms/Noise.py
@@ -1,23 +1,41 @@
 import numpy as np
 
 
-class NoPeakNoise(object):
-    def get_mz(self, mz, rt, intensity, ms_level):
-        return mz
+# Ensures that generators never return negative mz or intensity
+def trunc_normal(mean, sigma, log_space):
+    s = -1
+    if not log_space:
+        while s < 0:
+            s = np.random.normal(mean,sigma,1)[0]
+        return s
+    else:
+        s = np.random.normal(np.log(mean),sigma,1)[0]
+        return np.exp(s)
 
-    def get_intensity(self, mz, rt, intensity, ms_level):
-        return intensity
+class NoPeakNoise(object):
+    def get(self, original, ms_level):
+        return original
 
 
 class GaussianPeakNoise(NoPeakNoise):
-    def __init__(self, sigma_mz, sigma_int):
-        self.sigma_mz = sigma_mz
-        self.sigma_int = sigma_int
+    def __init__(self, sigma, log_space=False):
+        self.sigma = sigma
+        self.log_space = log_space
+    def get(self, original, ms_level):
+        return trunc_normal(original,self.sigma, self.log_space)
 
-    def get_mz(self, mz, rt, intensity, ms_level):
-        sampled = np.random.normal(mz, self.sigma_mz, 1)  # should be specified in ppm?
-        return sampled[0]
+# pass dictionary key: level, value: sigma.
+# ms_levels not in the dict will not have noise added
+# allows noise to be added to oa single level, or
+# to all levels with different sigma
+class GaussianPeakNoiseLevelSpecific(NoPeakNoise):
+    def __init__(self, sigma_level_dict, log_space=False):
+        self.log_space = log_space
+        self.sigma_level_dict = sigma_level_dict
+        
+    def get(self, original, ms_level):
+        if ms_level in self.sigma_level_dict:
+            return trunc_normal(original, self.sigma_level_dict[ms_level], self.log_space)
+        else:
+            return original
 
-    def get_intensity(self, mz, rt, intensity, ms_level):
-        sampled = np.random.normal(intensity, self.sigma_int, 1)  # maybe use the log intensity?
-        return sampled[0]


### PR DESCRIPTION
Fixes #69 

- MS now takes two arguments: a noise generator for m/z and one for intensity
- It calls the `get` method of these, passing the original value and the `ms_level`
- The same object could be used for both
- Default is still the `NoPeakNoise` object
- `GaussianPeakNoise` now has keyword boolean argument `log_space` which, if set to `True` will generate the noise on the log of the original, before returning the `exp`
- added a new class: `GaussianPeakNoiseSpecificLevels` that, instead of a scalar `sigma` argument, takes a dictionary with key: `ms_level` and value: `sigma`. Noise is then added to only those `ms_level` that have an entry in the dictionary, using the level-specific sigma.