### PR TITLE
Iss78

### DIFF
--- a/tests/integration/test_controllers.py
+++ b/tests/integration/test_controllers.py
@@ -15,6 +15,9 @@ from vimms.Environment import Environment
 from vimms.MassSpec import IndependentMassSpectrometer
 from vimms.Noise import *
 
+import numpy as np
+np.random.seed(1)
+
 ### define some useful constants ###
 
 DIR_PATH = os.path.dirname(os.path.realpath(__file__))

--- a/tests/integration/test_general.py
+++ b/tests/integration/test_general.py
@@ -6,6 +6,10 @@ from vimms.Chemicals import Formula
 
 import pytest
 
+import numpy as np
+np.random.seed(1)
+
+
 class TestFormula:
     def test_atom_counts(self):
         formula_string = 'Cl'

--- a/vimms/Chemicals.py
+++ b/vimms/Chemicals.py
@@ -1,6 +1,5 @@
 import copy
 import math
-import random
 import re
 from pathlib import Path
 
@@ -549,7 +548,9 @@ class MultiSampleCreator(object):
                 new_missing = list(np.where(np.random.binomial(1, self.dropout_probabilities[len(missing)],
                                                                len(self.original_dataset)))[0])
             if self.dropout_probabilities is None and self.dropout_numbers is not None:
-                new_missing = random.sample(range(0, len(self.original_dataset)), self.dropout_numbers)
+                # new_missing = random.sample(range(0, len(self.original_dataset)), self.dropout_numbers)
+                #  CHANGED BY SR, no testing. 
+                new_missing = list(np.random.choice(range(0, len(self.original_dataset)), self.dropout_numbers))
             missing.append(new_missing)
             missing = [list(x) for x in set(tuple(sorted(x)) for x in missing)]
         return missing


### PR DESCRIPTION
fixes #78 

- added seed setting into test scripts
- removed use of `random` in `Chemicals.py` so that all commands use `np.random`