### PR TITLE
Allow Top-N controller to receive an initial list of exclusions

### DIFF
--- a/tests/integration/test_controllers.py
+++ b/tests/integration/test_controllers.py
@@ -349,6 +349,34 @@ class TestTopNController:
         filename = 'topN_controller_simulated_chems_no_noise_onlyMH.mzML'
         check_mzML(env, OUT_DIR, filename)
 
+    def test_TopN_controller_with_beer_chems_and_initial_exclusion_list(self, fragscan_ps):
+        logger.info('Testing Top-N controller with QC beer chemicals and an initial exclusion list')
+
+        isolation_width = 1
+        N = 10
+        rt_tol = 15
+        mz_tol = 10
+        ionisation_mode = POSITIVE
+
+        initial_exclusion_list = None
+        for i in range(3):
+            mass_spec = IndependentMassSpectrometer(ionisation_mode, BEER_CHEMS, fragscan_ps)
+            controller = TopNController(ionisation_mode, N, isolation_width, mz_tol, rt_tol, MIN_MS1_INTENSITY,
+                                        initial_exclusion_list=initial_exclusion_list)
+            print('exclude = %d' % len(controller.exclusion_list))
+            env = Environment(mass_spec, controller, BEER_MIN_BOUND, BEER_MAX_BOUND, progress_bar=True)
+            run_environment(env)
+
+            if initial_exclusion_list is None:
+                initial_exclusion_list = []
+            initial_exclusion_list = initial_exclusion_list + list(controller.all_exclusion_items)
+
+            # check that there is at least one non-empty MS2 scan
+            check_non_empty_MS2(controller)
+
+            # write simulated output to mzML file
+            filename = 'topN_controller_qcbeer_exclusion_%d.mzML' % i
+            check_mzML(env, OUT_DIR, filename)
 
 
 class TestPurityController:

--- a/tests/integration/test_controllers.py
+++ b/tests/integration/test_controllers.py
@@ -369,7 +369,7 @@ class TestTopNController:
 
             if initial_exclusion_list is None:
                 initial_exclusion_list = []
-            initial_exclusion_list = initial_exclusion_list + list(controller.all_exclusion_items)
+            initial_exclusion_list = initial_exclusion_list + controller.all_exclusion_items
 
             # check that there is at least one non-empty MS2 scan
             check_non_empty_MS2(controller)

--- a/vimms/Controller/topN.py
+++ b/vimms/Controller/topN.py
@@ -50,7 +50,7 @@ class TopNController(Controller):
             self.exclusion_list = list(initial_exclusion_list)
 
         self.temp_exclusion_list = [] # to deal with ms1_shift
-        self.all_exclusion_items = set() # keep track of all exclusion items through the whole run
+        self.all_exclusion_items = [] # keep track of all exclusion items through the whole run
 
         # stores the mapping between precursor peak to ms2 scans
         self.precursor_information = defaultdict(list)  # key: Precursor object, value: ms2 scans
@@ -244,7 +244,7 @@ class TopNController(Controller):
                 x.from_mz, x.to_mz, x.from_rt, x.to_rt
             ))
             self.exclusion_list.append(x)
-            self.all_exclusion_items.add(x)
+            self.all_exclusion_items.append(x)
 
         # remove expired items from dynamic exclusion list
         self.exclusion_list = list(filter(lambda x: x.to_rt > current_time, self.exclusion_list))

--- a/vimms/Controller/topN.py
+++ b/vimms/Controller/topN.py
@@ -167,7 +167,7 @@ class TopNController(Controller):
             rt_tol = task.get(ScanParameters.DYNAMIC_EXCLUSION_RT_TOL)
             mz_lower = mz * (1 - mz_tol / 1e6)
             mz_upper = mz * (1 + mz_tol / 1e6)
-            rt_lower = rt
+            rt_lower = rt - rt_tol
             rt_upper = rt + rt_tol
             x = ExclusionItem(from_mz=mz_lower, to_mz=mz_upper, from_rt=rt_lower, to_rt=rt_upper)
             logger.debug('Time {:.6f} Created dynamic temporary exclusion window mz ({}-{}) rt ({}-{})'.format(
@@ -236,7 +236,7 @@ class TopNController(Controller):
             rt_tol = scan.scan_params.get(ScanParameters.DYNAMIC_EXCLUSION_RT_TOL)
             mz_lower = mz * (1 - mz_tol / 1e6)
             mz_upper = mz * (1 + mz_tol / 1e6)
-            rt_lower = current_time
+            rt_lower = current_time - rt_tol
             rt_upper = current_time + rt_tol
             x = ExclusionItem(from_mz=mz_lower, to_mz=mz_upper, from_rt=rt_lower, to_rt=rt_upper)
             logger.debug('Time {:.6f} Created dynamic exclusion window mz ({}-{}) rt ({}-{})'.format(

--- a/vimms/Controller/topN.py
+++ b/vimms/Controller/topN.py
@@ -169,7 +169,7 @@ class TopNController(Controller):
             mz_upper = mz * (1 + mz_tol / 1e6)
             rt_lower = rt - rt_tol
             rt_upper = rt + rt_tol
-            x = ExclusionItem(from_mz=mz_lower, to_mz=mz_upper, from_rt=rt_lower, to_rt=rt_upper)
+            x = ExclusionItem(from_mz=mz_lower, to_mz=mz_upper, from_rt=rt_lower, to_rt=rt_upper, frag_at=rt)
             logger.debug('Time {:.6f} Created dynamic temporary exclusion window mz ({}-{}) rt ({}-{})'.format(
                 rt,
                 x.from_mz, x.to_mz, x.from_rt, x.to_rt
@@ -238,7 +238,7 @@ class TopNController(Controller):
             mz_upper = mz * (1 + mz_tol / 1e6)
             rt_lower = current_time - rt_tol
             rt_upper = current_time + rt_tol
-            x = ExclusionItem(from_mz=mz_lower, to_mz=mz_upper, from_rt=rt_lower, to_rt=rt_upper)
+            x = ExclusionItem(from_mz=mz_lower, to_mz=mz_upper, from_rt=rt_lower, to_rt=rt_upper, frag_at=current_time)
             logger.debug('Time {:.6f} Created dynamic exclusion window mz ({}-{}) rt ({}-{})'.format(
                 current_time,
                 x.from_mz, x.to_mz, x.from_rt, x.to_rt
@@ -452,10 +452,10 @@ class WeightedDEWController(TopNController):
             if exclude_mz and exclude_rt:
                 logger.debug(
                     'Excluded precursor ion mz {:.4f} rt {:.2f} because of {}'.format(mz, rt, x))
-                if rt <= x.from_rt + self.exclusion_t_0:
+                if rt <= x.frag_at + self.exclusion_t_0:
                     return True, 0.0
                 else:
-                    weight = (rt - (self.exclusion_t_0 + x.from_rt)) / (self.rt_tol - self.exclusion_t_0)
+                    weight = (rt - (self.exclusion_t_0 + x.frag_at)) / (self.rt_tol - self.exclusion_t_0)
                     assert weight <= 1, weight
                     # self.remove_exclusion_items.append(x)
                     return True, weight

--- a/vimms/MassSpec.py
+++ b/vimms/MassSpec.py
@@ -201,7 +201,7 @@ class ExclusionItem(object):
     A class to store the item to exclude when computing dynamic exclusion window
     """
 
-    def __init__(self, from_mz, to_mz, from_rt, to_rt):
+    def __init__(self, from_mz, to_mz, from_rt, to_rt, frag_at):
         """
         Creates a dynamic exclusion item
         :param from_mz: m/z lower bounding box
@@ -213,6 +213,7 @@ class ExclusionItem(object):
         self.to_mz = to_mz
         self.from_rt = from_rt
         self.to_rt = to_rt
+        self.frag_at = frag_at
 
     def __repr__(self):
         return 'ExclusionItem mz=(%f, %f) rt=(%f-%f)' % (self.from_mz, self.to_mz, self.from_rt, self.to_rt)

--- a/vimms/MassSpec.py
+++ b/vimms/MassSpec.py
@@ -217,22 +217,12 @@ class ExclusionItem(object):
     def __repr__(self):
         return 'ExclusionItem mz=(%f, %f) rt=(%f-%f)' % (self.from_mz, self.to_mz, self.from_rt, self.to_rt)
 
-    def __lt__(self, other):
+    def __lt__(self,other):
         if self.from_mz <= other.from_mz:
             return True
         else:
             return False
 
-    def __eq__(self, other):
-        if not isinstance(other, ExclusionItem):
-            return NotImplemented
-        return self.from_mz == other.from_mz and \
-               self.to_mz == other.to_mz and \
-               self.from_rt == other.to_rt and \
-               self.to_rt and other.to_rt
-
-    def __hash__(self):
-        return hash((self.from_mz, self.to_mz, self.from_rt, self.to_rt))
 
 class IndependentMassSpectrometer(object):
     """


### PR DESCRIPTION
For issue #89 

The Top-N controller now accepts a parameter `initial_exclusion_list`. This is a list of precursor ions to be excluded during Top-N selection. The list can be obtained from e.g. a previous Top-N run.

Had to broaden the RT window when creating an exclusion item, so it could match the precursor ion in the next run https://github.com/sdrogers/vimms/compare/iss_89?expand=1#diff-c6299074495d125a6af6e704ba2434ddR170. Maybe this will help with RT drift too.

To test, please run `test_TopN_controller_with_beer_chems_and_initial_exclusion_list`