### PR TITLE
Controller has too many parameters in the constructor

### DIFF
--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -8,7 +8,7 @@ from vimms.ChemicalSamplers import UniformMZFormulaSampler, UniformRTAndIntensit
 from vimms.Chemicals import ChemicalCreator, ChemicalMixtureCreator
 from vimms.Common import *
 from vimms.Controller import TopNController, PurityController, TopN_RoiController, AIF, \
-    TopN_SmartRoiController, WeightedDEWController, ScheduleGenerator, FixedScansController, SWATH
+    TopN_SmartRoiController, WeightedDEWController, ScheduleGenerator, FixedScansController, SWATH, AdvancedParams
 from vimms.Controller.fullscan import SimpleMs1Controller
 from vimms.Environment import Environment
 from vimms.MassSpec import IndependentMassSpectrometer, ScanParameters
@@ -210,7 +210,9 @@ class TestMS1Controller:
 
         # create a simulated mass spec and MS1 controller
         mass_spec = IndependentMassSpectrometer(POSITIVE, BEER_CHEMS, fullscan_ps)
-        controller = SimpleMs1Controller(default_ms1_scan_window=(min_mz, max_mz))
+        params = AdvancedParams()
+        params.default_ms1_scan_window = (min_mz, max_mz)
+        controller = SimpleMs1Controller(params=params)
 
         # create an environment to run both the mass spec and controller
         env = Environment(mass_spec, controller, BEER_MIN_BOUND, BEER_MAX_BOUND, progress_bar=True)

--- a/vimms/Controller/fullscan.py
+++ b/vimms/Controller/fullscan.py
@@ -1,6 +1,3 @@
-from vimms.Common import DEFAULT_MS1_AGC_TARGET, DEFAULT_MS1_MAXIT, DEFAULT_MS1_COLLISION_ENERGY, \
-    DEFAULT_MS1_ORBITRAP_RESOLUTION, DEFAULT_MS1_SCAN_WINDOW, DEFAULT_MS1_ACTIVATION_TYPE, DEFAULT_MS1_MASS_ANALYSER, \
-    DEFAULT_MS1_ISOLATION_MODE
 from vimms.Controller import Controller
 
 
@@ -9,8 +6,8 @@ class IdleController(Controller):
     A controller that doesn't do any controlling.
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, params=None):
+        super().__init__(params=params)
 
     def _process_scan(self, scan):
         new_tasks = []
@@ -28,36 +25,11 @@ class SimpleMs1Controller(Controller):
     A simple MS1 controller which does a full scan of the chemical sample, but no fragmentation
     """
 
-    def __init__(self,
-                 # advanced parameters
-                 # advanced parameters
-                 ms1_agc_target=DEFAULT_MS1_AGC_TARGET,
-                 ms1_max_it=DEFAULT_MS1_MAXIT,
-                 ms1_collision_energy=DEFAULT_MS1_COLLISION_ENERGY,
-                 ms1_orbitrap_resolution=DEFAULT_MS1_ORBITRAP_RESOLUTION,
-                 ms1_activation_type=DEFAULT_MS1_ACTIVATION_TYPE,
-                 ms1_mass_analyser=DEFAULT_MS1_MASS_ANALYSER,
-                 ms1_isolation_mode=DEFAULT_MS1_ISOLATION_MODE,
-                 default_ms1_scan_window=DEFAULT_MS1_SCAN_WINDOW):
-        super().__init__()
-        self.ms1_agc_target = ms1_agc_target
-        self.ms1_max_it = ms1_max_it
-        self.ms1_collision_energy = ms1_collision_energy
-        self.ms1_orbitrap_resolution = ms1_orbitrap_resolution
-        self.ms1_activation_type = ms1_activation_type
-        self.ms1_mass_analyser = ms1_mass_analyser
-        self.ms1_isolation_mode = ms1_isolation_mode
-        self.default_ms1_scan_window = default_ms1_scan_window
+    def __init__(self, params=None):
+        super().__init__(params=params)
 
     def _process_scan(self, scan):
-        task = self.environment.get_default_scan_params(default_ms1_scan_window=self.default_ms1_scan_window,
-                                                        agc_target=self.ms1_agc_target,
-                                                        max_it=self.ms1_max_it,
-                                                        collision_energy=self.ms1_collision_energy,
-                                                        orbitrap_resolution=self.ms1_orbitrap_resolution,
-                                                        activation_type=self.ms1_activation_type,
-                                                        mass_analyser=self.ms1_mass_analyser,
-                                                        isolation_mode=self.ms1_isolation_mode)
+        task = self.get_ms1_scan_params();
         return [task]
 
     def update_state_after_scan(self, last_scan):

--- a/vimms/Controller/misc.py
+++ b/vimms/Controller/misc.py
@@ -2,10 +2,7 @@ import numpy as np
 import pandas as pd
 from loguru import logger
 
-from vimms.Common import DEFAULT_MS1_AGC_TARGET, DEFAULT_MS1_MAXIT, DEFAULT_MS1_COLLISION_ENERGY, \
-    DEFAULT_MS1_ORBITRAP_RESOLUTION, DEFAULT_MS1_ACTIVATION_TYPE, DEFAULT_MS1_MASS_ANALYSER, DEFAULT_MS1_ISOLATION_MODE, \
-    DEFAULT_MS2_AGC_TARGET, DEFAULT_MS2_MAXIT, DEFAULT_MS2_COLLISION_ENERGY, DEFAULT_MS2_ORBITRAP_RESOLUTION, \
-    DEFAULT_MS2_ACTIVATION_TYPE, DEFAULT_MS2_MASS_ANALYSER, DEFAULT_MS2_ISOLATION_MODE, DEFAULT_ISOLATION_WIDTH
+from vimms.Common import DEFAULT_ISOLATION_WIDTH
 from vimms.Controller.base import Controller
 
 
@@ -16,43 +13,12 @@ class FixedScansController(Controller):
 
     def __init__(self, ionisation_mode, schedule,
                  isolation_width=DEFAULT_ISOLATION_WIDTH,
-                 # advanced parameters
-                 ms1_agc_target=DEFAULT_MS1_AGC_TARGET,
-                 ms1_max_it=DEFAULT_MS1_MAXIT,
-                 ms1_collision_energy=DEFAULT_MS1_COLLISION_ENERGY,
-                 ms1_orbitrap_resolution=DEFAULT_MS1_ORBITRAP_RESOLUTION,
-                 ms1_activation_type=DEFAULT_MS1_ACTIVATION_TYPE,
-                 ms1_mass_analyser=DEFAULT_MS1_MASS_ANALYSER,
-                 ms1_isolation_mode=DEFAULT_MS1_ISOLATION_MODE,
-                 ms2_agc_target=DEFAULT_MS2_AGC_TARGET,
-                 ms2_max_it=DEFAULT_MS2_MAXIT,
-                 ms2_collision_energy=DEFAULT_MS2_COLLISION_ENERGY,
-                 ms2_orbitrap_resolution=DEFAULT_MS2_ORBITRAP_RESOLUTION,
-                 ms2_activation_type=DEFAULT_MS2_ACTIVATION_TYPE,
-                 ms2_mass_analyser=DEFAULT_MS2_MASS_ANALYSER,
-                 ms2_isolation_mode=DEFAULT_MS2_ISOLATION_MODE):
-        super().__init__()
+                 params=None):
+        super().__init__(params=params)
 
         self.ionisation_mode = ionisation_mode
         self.isolation_width = isolation_width
         self.schedule = schedule
-
-        # advanced parameters
-        self.ms1_agc_target = ms1_agc_target
-        self.ms1_max_it = ms1_max_it
-        self.ms1_collision_energy = ms1_collision_energy
-        self.ms1_orbitrap_resolution = ms1_orbitrap_resolution
-        self.ms1_activation_type = ms1_activation_type
-        self.ms1_mass_analyser = ms1_mass_analyser
-        self.ms1_isolation_mode = ms1_isolation_mode
-
-        self.ms2_agc_target = ms2_agc_target
-        self.ms2_max_it = ms2_max_it
-        self.ms2_collision_energy = ms2_collision_energy
-        self.ms2_orbitrap_resolution = ms2_orbitrap_resolution
-        self.ms2_activation_type = ms2_activation_type
-        self.ms2_mass_analyser = ms2_mass_analyser
-        self.ms2_isolation_mode = ms2_isolation_mode
 
     def get_initial_tasks(self):
         if isinstance(self.schedule, list):  # allows sending list of tasks
@@ -81,14 +47,14 @@ class FixedScansController(Controller):
         for idx, row in schedule.iterrows():
             if row['ms_level'] == 1:
                 self.last_ms1_id = self.current_task_id
-                agc_target = self._get_value_or_default(row, 'agc_target', self.ms1_agc_target)
-                max_it = self._get_value_or_default(row, 'max_it', self.ms1_max_it)
-                collision_energy = self._get_value_or_default(row, 'collision_energy', self.ms1_collision_energy)
+                agc_target = self._get_value_or_default(row, 'agc_target', self.params.ms1_agc_target)
+                max_it = self._get_value_or_default(row, 'max_it', self.params.ms1_max_it)
+                collision_energy = self._get_value_or_default(row, 'collision_energy', self.params.ms1_collision_energy)
                 orbitrap_resolution = self._get_value_or_default(row, 'orbitrap_resolution',
-                                                                 self.ms1_orbitrap_resolution)
-                activation_type = self._get_value_or_default(row, 'activation_type', self.ms1_activation_type)
-                mass_analyser = self._get_value_or_default(row, 'mass_analyser', self.ms1_mass_analyser)
-                isolation_mode = self._get_value_or_default(row, 'isolation_mode', self.ms1_isolation_mode)
+                                                                 self.params.ms1_orbitrap_resolution)
+                activation_type = self._get_value_or_default(row, 'activation_type', self.params.ms1_activation_type)
+                mass_analyser = self._get_value_or_default(row, 'mass_analyser', self.params.ms1_mass_analyser)
+                isolation_mode = self._get_value_or_default(row, 'isolation_mode', self.params.ms1_isolation_mode)
                 ms1_scan_params = self.environment.get_default_scan_params(agc_target=agc_target,
                                                                            max_it=max_it,
                                                                            collision_energy=collision_energy,
@@ -102,14 +68,14 @@ class FixedScansController(Controller):
                 precursor_mz = row['precursor_mz']
                 precursor_intensity = 100
                 isolation_width = self._get_value_or_default(row, 'isolation_width', self.isolation_width)
-                agc_target = self._get_value_or_default(row, 'agc_target', self.ms2_agc_target)
-                max_it = self._get_value_or_default(row, 'max_it', self.ms2_max_it)
-                collision_energy = self._get_value_or_default(row, 'collision_energy', self.ms2_collision_energy)
+                agc_target = self._get_value_or_default(row, 'agc_target', self.params.ms2_agc_target)
+                max_it = self._get_value_or_default(row, 'max_it', self.params.ms2_max_it)
+                collision_energy = self._get_value_or_default(row, 'collision_energy', self.params.ms2_collision_energy)
                 orbitrap_resolution = self._get_value_or_default(row, 'orbitrap_resolution',
-                                                                 self.ms2_orbitrap_resolution)
-                activation_type = self._get_value_or_default(row, 'activation_type', self.ms2_activation_type)
-                mass_analyser = self._get_value_or_default(row, 'mass_analyser', self.ms2_mass_analyser)
-                isolation_mode = self._get_value_or_default(row, 'isolation_mode', self.ms2_isolation_mode)
+                                                                 self.params.ms2_orbitrap_resolution)
+                activation_type = self._get_value_or_default(row, 'activation_type', self.params.ms2_activation_type)
+                mass_analyser = self._get_value_or_default(row, 'mass_analyser', self.params.ms2_mass_analyser)
+                isolation_mode = self._get_value_or_default(row, 'isolation_mode', self.params.ms2_isolation_mode)
                 dda_scan_params = self.environment.get_dda_scan_param(precursor_mz, precursor_intensity,
                                                                       precursor_scan_id,
                                                                       isolation_width, 0, 0,


### PR DESCRIPTION
Fixes for #77 

- Created an [`AdvancedParams`](https://github.com/sdrogers/vimms/blob/iss_77/vimms/Controller/base.py#L8-L41) class to hold all the advanced mass spec params (like AGC, maxit, etc) that are shared by all controller classes.
- We can pass this `AdvancedParams` to the base [`Controller`](https://github.com/sdrogers/vimms/blob/iss_77/vimms/Controller/base.py#L44-L49) class. When this is set to None, an instance of `AdvancedParams` is created with all the default values.
```
class Controller(object):
    def __init__(self, params=None):
        if params is None:
            self.params = AdvancedParams()
        else:
            self.params = params
```
- Made sure that all classes that extend from `Controller` passes this param to the super constructor, instead of having the huge number of parameters in each controller before, e.g. [in TopN](https://github.com/sdrogers/vimms/blob/iss_77/vimms/Controller/topN.py#L17-L19) now it is:
```
class TopNController(Controller):
    def __init__(self, ionisation_mode, N, isolation_width, mz_tol, rt_tol, min_ms1_intensity,
                 ms1_shift=0, initial_exclusion_list=None, params=None):
        super().__init__(params=params)
```
- Finally, added two methods in the base class [`get_ms1_scan_params`](https://github.com/sdrogers/vimms/blob/iss_77/vimms/Controller/base.py#L59-L68) and [`get_ms2_scan_params`](https://github.com/sdrogers/vimms/blob/iss_77/vimms/Controller/base.py#L70-L80) to generate the actual scan params making use of the `self.params` property stored above. (Almost) all controllers were modified to call these two methods when making the MS1 and MS2 scans.

```
                dda_scan_params = self.get_ms2_scan_params(mz, intensity, precursor_scan_id, self.isolation_width,
                                                           self.mz_tol, self.rt_tol)
                new_tasks.append(dda_scan_params)
```
- Would be nice if `get_ms1_scan_params` and `get_ms2_scan_params` don't need to depend on [`get_default_scan_params`](https://github.com/sdrogers/vimms/blob/iss_77/vimms/Environment.py#L182-L206) and [`get_dda_scan_params`](https://github.com/sdrogers/vimms/blob/iss_77/vimms/Environment.py#L208-L266) from the environment. See issue #121. 