### PR TITLE
Iss 174

### DIFF
--- a/tests/test_controllers_targeted.py
+++ b/tests/test_controllers_targeted.py
@@ -22,8 +22,8 @@ class TestTargetedController:
         d = cs.sample(2, 2)  # sample chems with m/z = 100 and 200
         ionisation_mode = POSITIVE
         targets = []
-        targets.append(Target(101, 100, 102, 10, 20))
-        targets.append(Target(201, 200, 202, 10, 20))
+        targets.append(Target(101, 100, 102, 10, 20, adduct='M+H'))
+        targets.append(Target(201, 200, 202, 10, 20, metadata={'a': 1}))
         ce_values = [10, 20, 30]
         n_replicates = 4
         controller = TargetedController(targets, ce_values, n_replicates=n_replicates, limit_acquisition=True)

--- a/vimms/Controller/base.py
+++ b/vimms/Controller/base.py
@@ -66,7 +66,7 @@ class Controller(object):
         self.initial_scan_id = INITIAL_SCAN_ID
         self.current_task_id = self.initial_scan_id
 
-    def get_ms1_scan_params(self):
+    def get_ms1_scan_params(self, metadata=None):
         task = self.environment.get_default_scan_params(default_ms1_scan_window=self.params.default_ms1_scan_window,
                                                         agc_target=self.params.ms1_agc_target,
                                                         max_it=self.params.ms1_max_it,
@@ -75,10 +75,11 @@ class Controller(object):
                                                         orbitrap_resolution=self.params.ms1_orbitrap_resolution,
                                                         activation_type=self.params.ms1_activation_type,
                                                         mass_analyser=self.params.ms1_mass_analyser,
-                                                        isolation_mode=self.params.ms1_isolation_mode)
+                                                        isolation_mode=self.params.ms1_isolation_mode,
+                                                        metadata=metadata)
         return task
 
-    def get_ms2_scan_params(self, mz, intensity, precursor_scan_id, isolation_width, mz_tol, rt_tol):
+    def get_ms2_scan_params(self, mz, intensity, precursor_scan_id, isolation_width, mz_tol, rt_tol, metadata=None):
         task = self.environment.get_dda_scan_param(mz, intensity, precursor_scan_id,
                                                    isolation_width, mz_tol, rt_tol,
                                                    agc_target=self.params.ms2_agc_target,
@@ -88,7 +89,8 @@ class Controller(object):
                                                    orbitrap_resolution=self.params.ms2_orbitrap_resolution,
                                                    activation_type=self.params.ms2_activation_type,
                                                    mass_analyser=self.params.ms2_mass_analyser,
-                                                   isolation_mode=self.params.ms2_isolation_mode)
+                                                   isolation_mode=self.params.ms2_isolation_mode,
+                                                   metadata=metadata)
         return task
 
     def get_initial_tasks(self):

--- a/vimms/Controller/base.py
+++ b/vimms/Controller/base.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 
+import pandas as pd
 import pylab as plt
 from loguru import logger
 
@@ -145,6 +146,24 @@ class Controller(object):
 
     def update_state_after_scan(self, last_scan):
         raise NotImplementedError()
+
+    def dump_scans(self, output_method):
+        all_scans = self.scans[1] + self.scans[2]
+        all_scans.sort(key=lambda x: x.scan_id)  # sort by scan_id
+        out_list = []
+        for scan in all_scans:
+            out = {
+                'scan_id': scan.scan_id,
+                'num_peaks': scan.num_peaks,
+                'rt': scan.rt,
+                'ms_level': scan.ms_level
+            }
+            out.update(scan.scan_params.get_all())  # add all the scan params to out
+            out_list.append(out)
+
+        # dump to csv
+        df = pd.DataFrame(out_list)
+        output_method(df.to_csv(index=False, line_terminator='\n'))
 
     def _process_scan(self, scan):
         raise NotImplementedError()

--- a/vimms/Controller/targeted.py
+++ b/vimms/Controller/targeted.py
@@ -136,9 +136,11 @@ class TargetedController(Controller):
                 # make some MS2 scans, upto N
                 for i in range(min(len(target_list), self.N)):
                     t, ce, _ = target_list[i]
-                    metadata = {'adduct': t.adduct}
+                    metadata = {}
+                    if t.adduct is not None:
+                        metadata['adduct'] = t.adduct
                     if t.metadata is not None:
-                        metadata = dict(t.metadata) # copy the rest of metadata from target
+                        metadata.update(t.metadata) # copy the rest of metadata from target
                     dda_scan_params = self.get_ms2_scan_params(t.mz, 1e3, precursor_scan_id, self.isolation_width, \
                                                         self.mz_tol, self.rt_tol, metadata=metadata)
                     dda_scan_params.set(ScanParameters.COLLISION_ENERGY, ce)

--- a/vimms/Controller/targeted.py
+++ b/vimms/Controller/targeted.py
@@ -136,8 +136,10 @@ class TargetedController(Controller):
                 # make some MS2 scans, upto N
                 for i in range(min(len(target_list), self.N)):
                     t, ce, _ = target_list[i]
+                    metadata = dict(t.metadata) # copy
+                    metadata['adduct'] = t.adduct
                     dda_scan_params = self.get_ms2_scan_params(t.mz, 1e3, precursor_scan_id, self.isolation_width, \
-                                                        self.mz_tol, self.rt_tol)
+                                                        self.mz_tol, self.rt_tol, metadata=metadata)
                     dda_scan_params.set(ScanParameters.COLLISION_ENERGY, ce)
                     new_tasks.append(dda_scan_params)
                     self.current_task_id += 1

--- a/vimms/Controller/targeted.py
+++ b/vimms/Controller/targeted.py
@@ -136,8 +136,9 @@ class TargetedController(Controller):
                 # make some MS2 scans, upto N
                 for i in range(min(len(target_list), self.N)):
                     t, ce, _ = target_list[i]
-                    metadata = dict(t.metadata) # copy
-                    metadata['adduct'] = t.adduct
+                    metadata = {'adduct': t.adduct}
+                    if t.metadata is not None:
+                        metadata = dict(t.metadata) # copy the rest of metadata from target
                     dda_scan_params = self.get_ms2_scan_params(t.mz, 1e3, precursor_scan_id, self.isolation_width, \
                                                         self.mz_tol, self.rt_tol, metadata=metadata)
                     dda_scan_params.set(ScanParameters.COLLISION_ENERGY, ce)

--- a/vimms/Environment.py
+++ b/vimms/Environment.py
@@ -192,7 +192,9 @@ class Environment(object):
                                 orbitrap_resolution=DEFAULT_MS1_ORBITRAP_RESOLUTION,
                                 default_ms1_scan_window=DEFAULT_MS1_SCAN_WINDOW,
                                 mass_analyser=DEFAULT_MS1_MASS_ANALYSER,
-                                activation_type=DEFAULT_MS1_ACTIVATION_TYPE, isolation_mode=DEFAULT_MS1_ISOLATION_MODE):
+                                activation_type=DEFAULT_MS1_ACTIVATION_TYPE,
+                                isolation_mode=DEFAULT_MS1_ISOLATION_MODE,
+                                metadata=None):
         """
         Gets the default method scan parameters. Now it's set to do MS1 scan only.
         :return: the default scan parameters
@@ -212,14 +214,18 @@ class Environment(object):
         default_scan_params.set(ScanParameters.POLARITY, self.mass_spec.ionisation_mode)
         default_scan_params.set(ScanParameters.FIRST_MASS, default_ms1_scan_window[0])
         default_scan_params.set(ScanParameters.LAST_MASS, default_ms1_scan_window[1])
+        default_scan_params.set(ScanParameters.METADATA, metadata)
         return default_scan_params
 
     def get_dda_scan_param(self, mz, intensity, precursor_scan_id, isolation_width, mz_tol, rt_tol,
                            agc_target=DEFAULT_MS2_AGC_TARGET, max_it=DEFAULT_MS2_MAXIT,
                            collision_energy=DEFAULT_MS2_COLLISION_ENERGY,
                            source_cid_energy=DEFAULT_SOURCE_CID_ENERGY,
-                           orbitrap_resolution=DEFAULT_MS2_ORBITRAP_RESOLUTION, mass_analyser=DEFAULT_MS2_MASS_ANALYSER,
-                           activation_type=DEFAULT_MS1_ACTIVATION_TYPE, isolation_mode=DEFAULT_MS2_ISOLATION_MODE):
+                           orbitrap_resolution=DEFAULT_MS2_ORBITRAP_RESOLUTION,
+                           mass_analyser=DEFAULT_MS2_MASS_ANALYSER,
+                           activation_type=DEFAULT_MS1_ACTIVATION_TYPE,
+                           isolation_mode=DEFAULT_MS2_ISOLATION_MODE,
+                           metadata=None):
         dda_scan_params = ScanParameters()
         dda_scan_params.set(ScanParameters.MS_LEVEL, 2)
 
@@ -267,6 +273,7 @@ class Environment(object):
         dda_scan_params.set(ScanParameters.SOURCE_CID_ENERGY, source_cid_energy)
         dda_scan_params.set(ScanParameters.POLARITY, self.mass_spec.ionisation_mode)
         dda_scan_params.set(ScanParameters.FIRST_MASS, DEFAULT_MSN_SCAN_WINDOW[0])
+        dda_scan_params.set(ScanParameters.METADATA, metadata)
 
         # dynamically scale the upper mass
         charge = 1

--- a/vimms/MassSpec.py
+++ b/vimms/MassSpec.py
@@ -97,6 +97,7 @@ class ScanParameters(object):
     ACTIVATION_TYPE = 'activation_type'
     ISOLATION_MODE = 'isolation_mode'
     SOURCE_CID_ENERGY = 'source_cid_energy'
+    METADATA = 'metadata'
 
     # this is used for DIA-based controllers to specify which windows to fragment
     ISOLATION_WINDOWS = 'isolation_windows'

--- a/vimms/MassSpec.py
+++ b/vimms/MassSpec.py
@@ -140,6 +140,9 @@ class ScanParameters(object):
         else:
             return None
 
+    def get_all(self):
+        return self.params
+
     def compute_isolation_windows(self):
         """
         Gets the full-width (DDA) isolation window around a precursor m/z


### PR DESCRIPTION
Fixes for https://github.com/sdrogers/vimms/issues/174. Also in general, this fix allows all controllers to dump their scans, their associated scan parameters, and any metadata we provide for that scan. Useful when we need to know which scan params produce which scans.

Changes:
 
- When making an MS1 or MS2 scan, we can now pass an additional `metadata` field, e.g. below we store metadata from the target (`t`) and the adduct used to make this MS2 scan.
```
                    metadata = {}
                    if t.adduct is not None:
                        metadata['adduct'] = t.adduct
                    if t.metadata is not None:
                        metadata.update(t.metadata) # copy the rest of metadata from target

                    dda_scan_params = self.get_ms2_scan_params(t.mz, 1e3, precursor_scan_id, self.isolation_width, \
                                                        self.mz_tol, self.rt_tol)
                                                        self.mz_tol, self.rt_tol, metadata=metadata)
```
The metadata is not used for any computation. It is just stored as part of the scan_params object for that scan, so it can be dumped with the rest of the scan parameters.

- Call the method `dump_scans` in the base controller to dump all scan information, including everything in the scan params as CSV format, e.g. for printing
```
        controller.dump_scans(print)
```
You can also dump to file by passing a suitable function to `dump_scans`, e.g. 
```
def csv_to_file(output):
    with open(fname, 'a') as out:
        out.write(output)

fname = 'output.csv'
controller.dump_scans(csv_to_file)
```

Example output from targeted controller: [simulated_targeted_std1_Positive_scans.zip](https://github.com/sdrogers/vimms/files/5277029/simulated_targeted_std1_Positive_scans.zip)
