### PR TITLE
Iss 195

### DIFF
--- a/vimms/Common.py
+++ b/vimms/Common.py
@@ -341,19 +341,31 @@ def take_closest(my_list, my_number):
         return pos - 1
 
 
-def set_log_level_warning():
-    logger.remove()
-    logger.add(sys.stderr, level=logging.WARNING)
+def set_log_level(level, remove_id=None):
+    if remove_id is None:
+        logger.remove(0)  # remove default handler
+    else:
+        logger.remove(remove_id)  # remove previously set handler
+
+    # add new handler at the desired log level
+    new_handler_id = logger.add(sys.stderr, level=level)
+    return new_handler_id
 
 
-def set_log_level_info():
-    logger.remove()
-    logger.add(sys.stderr, level=logging.INFO)
+def set_log_level_warning(remove_id=None):
+    return set_log_level(logging.WARNING, remove_id=remove_id)
 
 
-def set_log_level_debug():
-    logger.remove()
-    logger.add(sys.stderr, level=logging.DEBUG)
+def set_log_level_info(remove_id=None):
+    return set_log_level(logging.INFO, remove_id=remove_id)
+
+
+def set_log_level_debug(remove_id=None):
+    return set_log_level(logging.DEBUG, remove_id=remove_id)
+
+
+def add_log_file(log_path, level):
+    logger.add(log_path, level=level)
 
 
 def get_rt(spectrum):

--- a/vimms/Common.py
+++ b/vimms/Common.py
@@ -348,9 +348,12 @@ def take_closest(my_list, my_number):
 
 def set_log_level(level, remove_id=None):
     if remove_id is None:
-        logger.remove(0)  # remove default handler
+        try:
+            logger.remove(0)  # try to remove the default handler with id 0
+        except ValueError: # no default handler has been set
+            pass
     else:
-        logger.remove(remove_id)  # remove previously set handler
+        logger.remove(remove_id)  # remove previously set handler by id
 
     # add new handler at the desired log level
     new_handler_id = logger.add(sys.stderr, level=level)

--- a/vimms/Common.py
+++ b/vimms/Common.py
@@ -102,6 +102,11 @@ DEFAULT_MZML_CHEMICAL_CREATOR_PARAMS = {
 MSDIAL_DDA_MODE = 'lcmsdda'
 MSDIAL_DIA_MODE = 'lcmsdia'
 
+IN_SILICO_OPTIMISE_TOPN = 'TopN'
+IN_SILICO_OPTIMISE_SMART_ROI = 'SmartROI'
+IN_SILICO_OPTIMISE_WEIGHTED_DEW = 'WeightedDEW'
+
+
 ########################################################################################################################
 # Common classes
 ########################################################################################################################

--- a/vimms/InSilicoSimulation.py
+++ b/vimms/InSilicoSimulation.py
@@ -1,0 +1,295 @@
+# Supporting methods needed to run in-silico optimisation of controllers in scripts/in_silico_optimise.py
+import glob
+import json
+import os
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+from loguru import logger
+from mass_spec_utils.data_import.mzmine import map_boxes_to_scans
+from mass_spec_utils.data_import.mzml import MZMLFile
+from mass_spec_utils.data_processing.mzmine import pick_peaks
+
+from vimms.Chemicals import ChemicalMixtureFromMZML
+from vimms.Common import set_log_level_warning, set_log_level_debug
+from vimms.Controller import TopNController, load_picked_boxes, TopN_SmartRoiController, WeightedDEWController
+from vimms.Environment import Environment
+from vimms.MassSpec import IndependentMassSpectrometer
+from vimms.Roi import RoiParams
+
+
+def extract_chemicals(seed_file, params_dict):
+    """
+    Extract chemicals from a seed file
+    :param seed_file: the seed file in mzML format, should be a DDA file (containing MS1 and MS2 scans)
+    :param params_dict: a dictionary of parameters to extract ROI
+    :return: a list of UnknownChemical objects
+    """
+    logger.info('Seed file = %s' % seed_file)
+    logger.info('params = %s' % params_dict)
+
+    rp = RoiParams(**params_dict)
+    cm = ChemicalMixtureFromMZML(seed_file, roi_params=rp)
+    dataset = cm.sample(None, 2)
+    return dataset
+
+
+def get_timing(time_dict_str):
+    """
+    Parses timing information in form of a JSON string to a dictionary
+    :param time_dict_str: a string of dictionary in JSON format.
+    :return: a dictionary of time information. Key should be the ms-level, 1 or 2, and
+    value is the average time of scans at that level
+    """
+    time_dict = json.loads(time_dict_str)
+    time_dict = {int(k): v for k, v in time_dict.items()}  # turn keys from string to int
+    logger.debug('Got timing dictionary from config file')
+    return time_dict
+
+
+def extract_timing(seed_file):
+    """
+    Extracts timing information from a seed file
+    :param seed_file: the seed file in mzML format, should be a DDA file (containing MS1 and MS2 scans)
+    :return: a dictionary of time information. Key should be the ms-level, 1 or 2, and
+    value is the average time of scans at that level
+    """
+    logger.debug('Extracting timing dictionary from seed file')
+    seed_mzml = MZMLFile(seed_file)
+
+    time_dict = {(1, 1): [], (1, 2): [], (2, 1): [], (2, 2): []}
+    for i, s in enumerate(seed_mzml.scans[:-1]):
+        current = s.ms_level
+        next_ = seed_mzml.scans[i + 1].ms_level
+        tup = (current, next_)
+        time_dict[tup].append(60 * seed_mzml.scans[i + 1].rt_in_minutes - 60 * s.rt_in_minutes)
+
+    # seed_file must contain timing on (1,2) and (2,2)
+    # i.e. it must be a DDA file with MS1 and MS2 scans
+    assert (1, 2) in time_dict and len(time_dict[(1, 2)]) > 0
+    assert (2, 2) in time_dict and len(time_dict[(2, 2)]) > 0
+
+    # construct timing dict in the right format for later use
+    new_time_dict = {}
+    for k, v in time_dict.items():
+        if k == (1, 2):
+            key = 1
+        elif k == (2, 2):
+            key = 2
+        else:
+            continue
+
+        mean = sum(v) / len(v)
+        new_time_dict[key] = mean
+        logger.debug('%d: %f' % (key, mean))
+
+    assert 1 in new_time_dict and 2 in new_time_dict
+    return new_time_dict
+
+
+def run_TopN(chems, ps, time_dict, params, out_dir):
+    """
+    Simulate TopN controller
+    :param chems: a list of UnknownChemicals present in the injection
+    :param ps: old PeakSampler object, now only used to generate MS2 scans (TODO: should be removed as part of issue #46)
+    :param params: a dictionary of parameters
+    :param out_file: output mzML file
+    :param out_dir: output directory
+    :return: None
+    """
+    logger.info('Running TopN simulation')
+    logger.info(params)
+
+    warn_handler_id = set_log_level_warning()
+    out_file = '%s_%s.mzML' % (params['controller_name'], params['sample_name'])
+    controller = TopNController(params['ionisation_mode'], params['N'], params['isolation_width'], params['mz_tol'],
+                                params['rt_tol'], params['min_ms1_intensity'])
+    mass_spec = IndependentMassSpectrometer(params['ionisation_mode'], chems, ps, scan_duration_dict=time_dict)
+    env = Environment(mass_spec, controller, params['min_rt'], params['max_rt'], progress_bar=True, out_dir=out_dir,
+                      out_file=out_file)
+    logger.info('Generating %s' % out_file)
+    env.run()
+    set_log_level_debug(remove_id=warn_handler_id)
+
+
+def run_SmartROI(chems, ps, time_dict, params, out_dir):
+    """
+    Simulate SmartROI controller
+    :param chems: a list of UnknownChemicals present in the injection
+    :param ps: old PeakSampler object, now only used to generate MS2 scans (TODO: should be removed as part of issue #46)
+    :param params: a dictionary of parameters
+    :param out_file: output mzML file
+    :param out_dir: output directory
+    :return: None
+    """
+    logger.info('Running SmartROI simulation')
+    logger.info(params)
+    warn_handler_id = set_log_level_warning()
+
+    iif_values = params['iif_values']
+    dp_values = params['dp_values']
+    sample_name = params['sample_name']
+    for iif in iif_values:
+        for dp in dp_values:
+            out_file = 'SMART_{}_{}_{}.mzml'.format(sample_name, iif, dp)
+            logger.warning('Generating %s' % out_file)
+            if os.path.isfile(os.path.join(out_dir, out_file)):
+                logger.warning('Already done')
+                continue
+
+            intensity_increase_factor = iif  # fragment ROI again if intensity increases 10 fold
+            drop_perc = dp / 100
+            reset_length_seconds = 1e6  # set so reset never happens
+
+            controller = TopN_SmartRoiController(params['ionisation_mode'], params['isolation_width'], params['mz_tol'],
+                                                 params['min_ms1_intensity'], params['min_roi_intensity'],
+                                                 params['min_roi_length'], N=params['N'], rt_tol=params['rt_tol'],
+                                                 min_roi_length_for_fragmentation=params[
+                                                     'min_roi_length_for_fragmentation'],
+                                                 reset_length_seconds=reset_length_seconds,
+                                                 intensity_increase_factor=intensity_increase_factor,
+                                                 drop_perc=drop_perc)
+
+            mass_spec = IndependentMassSpectrometer(params['ionisation_mode'], chems, ps, scan_duration_dict=time_dict)
+            env = Environment(mass_spec, controller, params['min_rt'], params['max_rt'], progress_bar=True,
+                              out_dir=out_dir, out_file=out_file)
+            env.run()
+    set_log_level_debug(remove_id=warn_handler_id)
+
+
+def run_WeightedDEW(chems, ps, time_dict, params, out_dir):
+    """
+    Simulate WeightedDEW controller
+    :param chems: a list of UnknownChemicals present in the injection
+    :param ps: old PeakSampler object, now only used to generate MS2 scans (TODO: should be removed as part of issue #46)
+    :param params: a dictionary of parameters
+    :param out_file: output mzML file
+    :param out_dir: output directory
+    :return: None
+    """
+    logger.info('Running WeightedDEW simulation')
+    logger.info(params)
+    warn_handler_id = set_log_level_warning()
+
+    t0_values = params['t0_values']
+    rt_tol_values = params['rt_tol_values']
+    sample_name = params['sample_name']
+    for t0 in t0_values:
+        for r in rt_tol_values:
+            out_file = 'WeightedDEW_{}_{}_{}.mzml'.format(sample_name, t0, r)
+            logger.warning('Generating %s' % out_file)
+            if os.path.isfile(os.path.join(out_dir, out_file)):
+                logger.warning('Already done')
+                continue
+            if t0 > r:
+                logger.warning('Impossible combination')
+                continue
+
+            controller = WeightedDEWController(params['ionisation_mode'], params['N'], params['isolation_width'],
+                                               params['mz_tol'], r, params['min_ms1_intensity'], exclusion_t_0=t0,
+                                               log_intensity=True)
+            mass_spec = IndependentMassSpectrometer(params['ionisation_mode'], chems, ps, scan_duration_dict=time_dict)
+            env = Environment(mass_spec, controller, params['min_rt'], params['max_rt'], progress_bar=True,
+                              out_dir=out_dir, out_file=out_file)
+            env.run()
+    set_log_level_debug(remove_id=warn_handler_id)
+
+
+def string_to_list(my_str, convert=None):
+    """
+    Convert a string representation of list into list
+    :param my_str: a string representation of list, e.g. '[1, 2, 3]'
+    :param convert: a function to convert data type of each element, e.g. float
+    :return: a list, e.g. [1, 2, 3]
+    """
+    if len(my_str) == 0:
+        return []
+    my_list = my_str.strip('][').split(', ')
+
+    if convert is not None:
+        my_list = list(map(convert, my_list))
+    return my_list
+
+
+def extract_boxes(seed_file, out_dir, mzmine_command, xml_file):
+    """
+    Extract peak picked boxes using MzMine2 peak picking
+    :param seed_file: the seed file in mzML format, should be a DDA file (containing MS1 and MS2 scans)
+    :param mzmine_command: path to MzMine2 batch file
+    :param xml_file: path to MzMine2 XML config file
+    :return: a list of boxes
+    """
+    # construct the path to the resulting peak picked CSV
+    seed_picked_peaks_csv = get_peak_picked_csv(seed_file)
+    logger.info('Peak picking, results will be in %s' % seed_picked_peaks_csv)
+
+    # run peak picking using MzMine2
+    pick_peaks([seed_file], xml_template=xml_file, output_dir=out_dir, mzmine_command=mzmine_command)
+
+    # the peak picked csv must exist at this point
+    assert Path(seed_picked_peaks_csv).is_file()
+    boxes = load_picked_boxes(seed_picked_peaks_csv)
+    logger.info('Loaded %d boxes from the seed file' % len(boxes))
+    return boxes
+
+
+def get_peak_picked_csv(seed_file):
+    """
+    From the seed file returns the path to the peak picked csv file from mzmine
+    :param seed_file: path to the seed file
+    :return: path to the peak picked csv file from mzine
+    """
+    base_name = os.path.basename(seed_file)
+    seed_picked_peaks = os.path.splitext(base_name)[0] + '_box.csv'
+    seed_dir = os.path.split(seed_file)[0]
+    seed_picked_peaks_csv = os.path.join(seed_dir, seed_picked_peaks)
+    return seed_picked_peaks_csv
+
+
+def evaluate_boxes_as_dict(boxes, out_dir):
+    counts = {}
+    for filename in glob.glob(os.path.join(out_dir, '*.mzML')):
+        basename = os.path.basename(filename)
+        mzml = MZMLFile(filename)
+        scans2boxes, boxes2scans = map_boxes_to_scans(mzml, boxes, half_isolation_window=0)
+        c = len(boxes2scans)
+        logger.info('- %s: found %d boxes with scans' % (basename, c))
+        counts[basename] = c
+    logger.debug(counts)
+    return counts
+
+
+def evaluate_boxes_as_array(boxes, out_dir, yticks, xticks, pattern, params):
+    sample_name = params['sample_name']
+    counts = np.zeros((len(yticks), len(xticks)))
+    for i, y in enumerate(yticks):
+        for j, x in enumerate(xticks):
+            try:
+                fname = pattern.format(sample_name, y, x)
+                mz_file = MZMLFile(os.path.join(out_dir, fname))
+                scans2boxes, boxes2scans = map_boxes_to_scans(mz_file, boxes, half_isolation_window=0)
+                counts[i, j] = len(boxes2scans)
+            except FileNotFoundError:
+                counts[i, j] = np.nan
+            logger.debug(counts)
+    return counts
+
+
+def save_counts(counts, out_dir, controller_name, sample_name):
+    fname = '%s_%s_counts.csv' % (controller_name, sample_name)
+    out_csv = os.path.join(out_dir, fname)
+    np.savetxt(out_csv, counts, delimiter=",")
+
+
+def plot_counts(counts, out_file, title, xlabel, xticks, ylabel, yticks):
+    plt.rcParams.update({'font.size': 16})
+    plt.imshow(counts, aspect='auto')
+    plt.yticks(range(len(yticks)), yticks)
+    plt.xticks(range(len(xticks)), xticks)
+    plt.xlabel(xlabel)
+    plt.ylabel(ylabel)
+    plt.colorbar()
+    plt.title(title)
+    plt.tight_layout()
+    plt.savefig(out_file, dpi=300)

--- a/vimms/scripts/config/SmartROI_config.txt
+++ b/vimms/scripts/config/SmartROI_config.txt
@@ -1,34 +1,34 @@
 [experiment]
-controller_name			= SmartROI
-min_rt 					= 0
-max_rt 					= 1560
-ionisation_mode 		= Positive
-isolation_width 		= 1
+controller_name	= SmartROI
+min_rt = 0
+max_rt = 1560
+ionisation_mode = Positive
+isolation_width = 1
 
 [roi_extraction]
-mz_tol 					= 5
-mz_units 				= ppm
-min_length 				= 1
-min_intensity 			= 0
+mz_tol = 5
+mz_units = ppm
+min_length = 1
+min_intensity = 0
 	
 [simulation]
-N 						= 10
-mz_tol 					= 10
-rt_tol 					= 15
-min_ms1_intensity 		= 5000
-iif_values 				= [2, 3, 5, 10, 1e3, 1e6]
-dp_values 				= [0, 0.1, 0.5, 1, 5]
-min_roi_intensity 		= 500
-min_roi_length 			= 3 
+N = 10
+mz_tol = 10
+rt_tol = 15
+min_ms1_intensity = 5000
+iif_values = [2, 3, 5, 10, 1e3, 1e6]
+dp_values = [0, 0.1, 0.5, 1, 5]
+min_roi_intensity = 500
+min_roi_length = 3 
 min_roi_length_for_fragmentation = 1
 
 # leave blank to compute timing from the seed data itself
-time_dict				= {"1": 0.71, "2": 0.20}
+time_dict = {"1": 0.71, "2": 0.20}
 
 # shouldn't be needed?
-ps_file 				= /Users/joewa/University of Glasgow/Vinny Davies - CLDS Metabolomics Project/Trained Models/peak_sampler_mz_rt_int_beerqcb_fragmentation.p 
+ps_file = /Users/joewa/University of Glasgow/Vinny Davies - CLDS Metabolomics Project/Trained Models/peak_sampler_mz_rt_int_beerqcb_fragmentation.p 
 
 [evaluation]
-mzmine_command			= /Users/joewa/work/MZmine-2.40.1/startMZmine_Windows.bat
-mzmine_xml_file			= /Users/joewa/Work/git/vimms/batch_files/QC_PP.xml
+mzmine_command = /Users/joewa/work/MZmine-2.40.1/startMZmine_Windows.bat
+mzmine_xml_file = /Users/joewa/Work/git/vimms/batch_files/QC_PP.xml
 

--- a/vimms/scripts/config/SmartROI_config.txt
+++ b/vimms/scripts/config/SmartROI_config.txt
@@ -1,0 +1,34 @@
+[experiment]
+controller_name			= SmartROI
+min_rt 					= 0
+max_rt 					= 1560
+ionisation_mode 		= Positive
+isolation_width 		= 1
+
+[roi_extraction]
+mz_tol 					= 5
+mz_units 				= ppm
+min_length 				= 1
+min_intensity 			= 0
+	
+[simulation]
+N 						= 10
+mz_tol 					= 10
+rt_tol 					= 15
+min_ms1_intensity 		= 5000
+iif_values 				= [2, 3, 5, 10, 1e3, 1e6]
+dp_values 				= [0, 0.1, 0.5, 1, 5]
+min_roi_intensity 		= 500
+min_roi_length 			= 3 
+min_roi_length_for_fragmentation = 1
+
+# leave blank to compute timing from the seed data itself
+time_dict				= {"1": 0.71, "2": 0.20}
+
+# shouldn't be needed?
+ps_file 				= /Users/joewa/University of Glasgow/Vinny Davies - CLDS Metabolomics Project/Trained Models/peak_sampler_mz_rt_int_beerqcb_fragmentation.p 
+
+[evaluation]
+mzmine_command			= /Users/joewa/work/MZmine-2.40.1/startMZmine_Windows.bat
+mzmine_xml_file			= /Users/joewa/Work/git/vimms/batch_files/QC_PP.xml
+

--- a/vimms/scripts/config/TopN_config.txt
+++ b/vimms/scripts/config/TopN_config.txt
@@ -1,0 +1,29 @@
+[experiment]
+controller_name			= TopN
+min_rt 					= 0
+max_rt 					= 1560
+ionisation_mode 		= Positive
+isolation_width 		= 1
+
+[roi_extraction]
+mz_tol 					= 5
+mz_units 				= ppm
+min_length 				= 1
+min_intensity 			= 0
+	
+[simulation]
+N 						= 10
+mz_tol 					= 10
+rt_tol 					= 15
+min_ms1_intensity 		= 5000
+
+# leave blank to compute timing from the seed data itself
+time_dict				= {"1": 0.60, "2": 0.20}
+
+# shouldn't be needed?
+ps_file 				= /Users/joewa/University of Glasgow/Vinny Davies - CLDS Metabolomics Project/Trained Models/peak_sampler_mz_rt_int_beerqcb_fragmentation.p 
+
+[evaluation]
+mzmine_command			= /Users/joewa/work/MZmine-2.40.1/startMZmine_Windows.bat
+mzmine_xml_file			= /Users/joewa/Work/git/vimms/batch_files/QC_PP.xml
+

--- a/vimms/scripts/config/TopN_config.txt
+++ b/vimms/scripts/config/TopN_config.txt
@@ -1,29 +1,29 @@
 [experiment]
-controller_name			= TopN
-min_rt 					= 0
-max_rt 					= 1560
-ionisation_mode 		= Positive
-isolation_width 		= 1
+controller_name = TopN
+min_rt = 0
+max_rt = 1560
+ionisation_mode = Positive
+isolation_width = 1
 
 [roi_extraction]
-mz_tol 					= 5
-mz_units 				= ppm
-min_length 				= 1
-min_intensity 			= 0
+mz_tol = 5
+mz_units = ppm
+min_length = 1
+min_intensity = 0
 	
 [simulation]
-N 						= 10
-mz_tol 					= 10
-rt_tol 					= 15
-min_ms1_intensity 		= 5000
+N = 10
+mz_tol = 10
+rt_tol = 15
+min_ms1_intensity = 5000
 
 # leave blank to compute timing from the seed data itself
-time_dict				= {"1": 0.60, "2": 0.20}
+time_dict = {"1": 0.60, "2": 0.20}
 
 # shouldn't be needed?
-ps_file 				= /Users/joewa/University of Glasgow/Vinny Davies - CLDS Metabolomics Project/Trained Models/peak_sampler_mz_rt_int_beerqcb_fragmentation.p 
+ps_file = /Users/joewa/University of Glasgow/Vinny Davies - CLDS Metabolomics Project/Trained Models/peak_sampler_mz_rt_int_beerqcb_fragmentation.p 
 
 [evaluation]
-mzmine_command			= /Users/joewa/work/MZmine-2.40.1/startMZmine_Windows.bat
-mzmine_xml_file			= /Users/joewa/Work/git/vimms/batch_files/QC_PP.xml
+mzmine_command = /Users/joewa/work/MZmine-2.40.1/startMZmine_Windows.bat
+mzmine_xml_file = /Users/joewa/Work/git/vimms/batch_files/QC_PP.xml
 

--- a/vimms/scripts/config/WeightedDEW_config.txt
+++ b/vimms/scripts/config/WeightedDEW_config.txt
@@ -1,30 +1,30 @@
 [experiment]
-controller_name			= WeightedDEW
-min_rt 					= 0
-max_rt 					= 1560
-ionisation_mode 		= Positive
-isolation_width 		= 1
+controller_name = WeightedDEW
+min_rt = 0
+max_rt = 1560
+ionisation_mode = Positive
+isolation_width = 1
 
 [roi_extraction]
-mz_tol 					= 5
-mz_units 				= ppm
-min_length 				= 1
-min_intensity 			= 0
+mz_tol = 5
+mz_units = ppm
+min_length = 1
+min_intensity = 0
 	
 [simulation]
-N 						= 10
-mz_tol 					= 10
-min_ms1_intensity 		= 5000
-t0_values 				= [1, 3, 10, 15, 30, 60]
-rt_tol_values 			= [15, 60, 120, 240, 360, 3600]
+N = 10
+mz_tol = 10
+min_ms1_intensity = 5000
+t0_values = [1, 3, 10, 15, 30, 60]
+rt_tol_values = [15, 60, 120, 240, 360, 3600]
 
 # leave blank to compute timing from the seed data itself
-time_dict				= {"1": 0.60, "2": 0.20}
+time_dict = {"1": 0.60, "2": 0.20}
 
 # shouldn't be needed?
-ps_file 				= /Users/joewa/University of Glasgow/Vinny Davies - CLDS Metabolomics Project/Trained Models/peak_sampler_mz_rt_int_beerqcb_fragmentation.p 
+ps_file = /Users/joewa/University of Glasgow/Vinny Davies - CLDS Metabolomics Project/Trained Models/peak_sampler_mz_rt_int_beerqcb_fragmentation.p 
 
 [evaluation]
-mzmine_command			= /Users/joewa/work/MZmine-2.40.1/startMZmine_Windows.bat
-mzmine_xml_file			= /Users/joewa/Work/git/vimms/batch_files/QC_PP.xml
+mzmine_command = /Users/joewa/work/MZmine-2.40.1/startMZmine_Windows.bat
+mzmine_xml_file = /Users/joewa/Work/git/vimms/batch_files/QC_PP.xml
 

--- a/vimms/scripts/config/WeightedDEW_config.txt
+++ b/vimms/scripts/config/WeightedDEW_config.txt
@@ -1,0 +1,30 @@
+[experiment]
+controller_name			= WeightedDEW
+min_rt 					= 0
+max_rt 					= 1560
+ionisation_mode 		= Positive
+isolation_width 		= 1
+
+[roi_extraction]
+mz_tol 					= 5
+mz_units 				= ppm
+min_length 				= 1
+min_intensity 			= 0
+	
+[simulation]
+N 						= 10
+mz_tol 					= 10
+min_ms1_intensity 		= 5000
+t0_values 				= [1, 3, 10, 15, 30, 60]
+rt_tol_values 			= [15, 60, 120, 240, 360, 3600]
+
+# leave blank to compute timing from the seed data itself
+time_dict				= {"1": 0.60, "2": 0.20}
+
+# shouldn't be needed?
+ps_file 				= /Users/joewa/University of Glasgow/Vinny Davies - CLDS Metabolomics Project/Trained Models/peak_sampler_mz_rt_int_beerqcb_fragmentation.p 
+
+[evaluation]
+mzmine_command			= /Users/joewa/work/MZmine-2.40.1/startMZmine_Windows.bat
+mzmine_xml_file			= /Users/joewa/Work/git/vimms/batch_files/QC_PP.xml
+

--- a/vimms/scripts/in_silico_optimise.py
+++ b/vimms/scripts/in_silico_optimise.py
@@ -1,0 +1,262 @@
+import argparse
+import configparser
+import os
+import sys
+
+sys.path.append('..')
+sys.path.append('../..')  # if running in this folder
+
+from vimms.Common import IN_SILICO_OPTIMISE_TOPN, load_obj, add_log_file, IN_SILICO_OPTIMISE_SMART_ROI, \
+    IN_SILICO_OPTIMISE_WEIGHTED_DEW
+from vimms.InSilicoSimulation import extract_chemicals, get_timing, extract_timing, run_TopN, run_SmartROI, \
+    run_WeightedDEW, extract_boxes, evaluate_boxes_as_dict, evaluate_boxes_as_array, save_counts, string_to_list, \
+    plot_counts
+
+
+class InSilicoSimulator(object):
+    def __init__(self, sample_name, seed_file, out_dir, controller_name, config_parser):
+        self.sample_name = sample_name
+        self.seed_file = seed_file
+        self.out_dir = out_dir
+        self.controller_name = controller_name
+        self.config_parser = config_parser
+
+    def run(self):
+        # get the chemicals, timing, peak sample object and parameters
+        chems = self.get_chems()
+        time_dict = self.get_time_dict()
+        ps = self.get_ps()
+        params = self.get_params()
+
+        # simulate controller and evaluate performance
+        self.simulate(chems, time_dict, ps, params)
+        self.evaluate(params)
+
+    def get_chems(self):
+        # extract chemicals from seed_file
+        params_dict = {
+            'mz_tol': self.config_parser.getint('roi_extraction', 'mz_tol'),
+            'mz_units': self.config_parser.get('roi_extraction', 'mz_units'),
+            'min_length': self.config_parser.getint('roi_extraction', 'min_length'),
+            'min_intensity': self.config_parser.getint('roi_extraction', 'min_intensity'),
+            'start_rt': self.config_parser.getint('experiment', 'min_rt'),
+            'stop_rt': self.config_parser.getint('experiment', 'max_rt')
+        }
+        chems = extract_chemicals(self.seed_file, params_dict)
+        return chems
+
+    def get_time_dict(self):
+        # if provided, read timing information from config
+        # otherwise extract timing from the seed file too
+        # parse time dict, this really should be computed from the data
+        time_dict_str = self.config_parser.get('simulation', 'time_dict')
+        time_dict = get_timing(time_dict_str) if len(time_dict_str) > 0 else extract_timing(self.seed_file)
+        return time_dict
+
+    def get_ps(self):
+        # TODO: this should go away as part of issue #46
+        ps_file = self.config_parser.get('simulation', 'ps_file')
+        ps = load_obj(ps_file)
+        return ps
+
+    def simulate(self):
+        raise NotImplementedError()
+
+    def evaluate(self, params):
+        raise NotImplementedError()
+
+
+class TopNSimulator(InSilicoSimulator):
+    def get_params(self):
+        # get experiment parameters
+        ionisation_mode = self.config_parser.get('experiment', 'ionisation_mode')
+        isolation_width = self.config_parser.getfloat('experiment', 'isolation_width')
+        min_rt = self.config_parser.getfloat('experiment', 'min_rt')
+        max_rt = self.config_parser.getint('experiment', 'max_rt')
+
+        # get simulation parameters
+        N = self.config_parser.getint('simulation', 'N')
+        mz_tol = self.config_parser.getint('simulation', 'mz_tol')
+        rt_tol = self.config_parser.getint('simulation', 'rt_tol')
+        min_ms1_intensity = self.config_parser.getint('simulation', 'min_ms1_intensity')
+
+        params = {
+            'controller_name': self.controller_name,
+            'ionisation_mode': ionisation_mode,
+            'sample_name': self.sample_name,
+            'isolation_width': isolation_width,
+            'N': N,
+            'mz_tol': mz_tol,
+            'rt_tol': rt_tol,
+            'min_ms1_intensity': min_ms1_intensity,
+            'min_rt': min_rt,
+            'max_rt': max_rt
+        }
+        return params
+
+    def simulate(self, chems, time_dict, ps, params):
+        run_TopN(chems, ps, time_dict, params, self.out_dir)
+
+    def evaluate(self, params):
+        xml_file = self.config_parser.get('evaluation', 'mzmine_xml_file')
+        mzmine_command = self.config_parser.get('evaluation', 'mzmine_command')
+        boxes = extract_boxes(self.seed_file, self.out_dir, mzmine_command, xml_file)
+        evaluate_boxes_as_dict(boxes, self.out_dir)
+
+
+class SmartROISimulator(InSilicoSimulator):
+    def get_params(self):
+        # get experiment parameters
+        ionisation_mode = self.config_parser.get('experiment', 'ionisation_mode')
+        isolation_width = self.config_parser.getfloat('experiment', 'isolation_width')
+        min_rt = self.config_parser.getfloat('experiment', 'min_rt')
+        max_rt = self.config_parser.getint('experiment', 'max_rt')
+
+        # get simulation parameters
+        N = self.config_parser.getint('simulation', 'N')
+        mz_tol = self.config_parser.getint('simulation', 'mz_tol')
+        rt_tol = self.config_parser.getint('simulation', 'rt_tol')
+        min_ms1_intensity = self.config_parser.getint('simulation', 'min_ms1_intensity')
+
+        # get additional SmartROI parameters
+        iif_values = self.config_parser.get('simulation', 'iif_values')
+        dp_values = self.config_parser.get('simulation', 'dp_values')
+        iif_values = string_to_list(iif_values, convert=float)
+        dp_values = string_to_list(dp_values, convert=float)
+
+        min_roi_intensity = self.config_parser.getfloat('simulation', 'min_roi_intensity')
+        min_roi_length = self.config_parser.getint('simulation', 'min_roi_length')
+        min_roi_length_for_fragmentation = self.config_parser.getint('simulation', 'min_roi_length_for_fragmentation')
+
+        params = {
+            'controller_name': self.controller_name,
+            'ionisation_mode': ionisation_mode,
+            'sample_name': self.sample_name,
+            'isolation_width': isolation_width,
+            'N': N,
+            'mz_tol': mz_tol,
+            'rt_tol': rt_tol,
+            'min_ms1_intensity': min_ms1_intensity,
+            'min_rt': min_rt,
+            'max_rt': max_rt,
+            'iif_values': iif_values,
+            'dp_values': dp_values,
+            'min_roi_intensity': min_roi_intensity,
+            'min_roi_length': min_roi_length,
+            'min_roi_length_for_fragmentation': min_roi_length_for_fragmentation
+        }
+        return params
+
+    def simulate(self, chems, time_dict, ps, params):
+        run_SmartROI(chems, ps, time_dict, params, self.out_dir)
+
+    def evaluate(self, params):
+        # extract peak boxes
+        xml_file = self.config_parser.get('evaluation', 'mzmine_xml_file')
+        mzmine_command = self.config_parser.get('evaluation', 'mzmine_command')
+        boxes = extract_boxes(self.seed_file, self.out_dir, mzmine_command, xml_file)
+
+        # extract counts
+        pattern = 'SMART_{}_{}_{}.mzml'
+        yticks = params['iif_values']
+        xticks = params['dp_values']
+        counts = evaluate_boxes_as_array(boxes, self.out_dir, yticks, xticks, pattern, params)
+        save_counts(counts, self.out_dir, params['controller_name'], params['sample_name'])
+
+        # plot counts
+        xlabel = r'$\beta$'
+        ylabel = r'$\alpha$'
+        title = 'SmartROI simulations (%s)' % self.sample_name
+        out_file = os.path.join(self.out_dir, '%s_%s.png' % (self.controller_name, self.sample_name))
+        plot_counts(counts, out_file, title, xlabel, xticks, ylabel, yticks)
+
+
+class WeightedDEWSimulator(InSilicoSimulator):
+    def get_params(self):
+        # get experiment parameters
+        ionisation_mode = self.config_parser.get('experiment', 'ionisation_mode')
+        isolation_width = self.config_parser.getfloat('experiment', 'isolation_width')
+        min_rt = self.config_parser.getfloat('experiment', 'min_rt')
+        max_rt = self.config_parser.getint('experiment', 'max_rt')
+
+        # get simulation parameters
+        N = self.config_parser.getint('simulation', 'N')
+        mz_tol = self.config_parser.getint('simulation', 'mz_tol')
+        min_ms1_intensity = self.config_parser.getint('simulation', 'min_ms1_intensity')
+
+        # get additional SmartROI parameters
+        t0_values = self.config_parser.get('simulation', 't0_values')
+        rt_tol_values = self.config_parser.get('simulation', 'rt_tol_values')
+        t0_values = string_to_list(t0_values, convert=float)
+        rt_tol_values = string_to_list(rt_tol_values, convert=float)
+
+        params = {
+            'controller_name': self.controller_name,
+            'ionisation_mode': ionisation_mode,
+            'sample_name': self.sample_name,
+            'isolation_width': isolation_width,
+            'N': N,
+            'mz_tol': mz_tol,
+            'min_ms1_intensity': min_ms1_intensity,
+            'min_rt': min_rt,
+            'max_rt': max_rt,
+            't0_values': t0_values,
+            'rt_tol_values': rt_tol_values
+        }
+        return params
+
+    def simulate(self, chems, time_dict, ps, params):
+        run_WeightedDEW(chems, ps, time_dict, params, self.out_dir)
+
+    def evaluate(self, params):
+        # extract peak boxes
+        xml_file = self.config_parser.get('evaluation', 'mzmine_xml_file')
+        mzmine_command = self.config_parser.get('evaluation', 'mzmine_command')
+        boxes = extract_boxes(self.seed_file, self.out_dir, mzmine_command, xml_file)
+
+        # extract counts
+        pattern = 'WeightedDEW_{}_{}_{}.mzml'
+        yticks = params['t0_values']
+        xticks = params['rt_tol_values']
+        counts = evaluate_boxes_as_array(boxes, self.out_dir, yticks, xticks, pattern, params)
+        save_counts(counts, self.out_dir, params['controller_name'], params['sample_name'])
+
+        xlabel = 't0'
+        ylabel = 'rt_tol'
+        title = 'WeightedDEW simulations (%s)' % self.sample_name
+        out_file = os.path.join(self.out_dir, '%s_%s.png' % (self.controller_name, self.sample_name))
+        plot_counts(counts, out_file, title, xlabel, xticks, ylabel, yticks)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='In-silico Optimisation of Fragmentation Strategy using ViMMS')
+    parser.add_argument('sample_name', type=str)
+    parser.add_argument('seed_file', type=str)
+    parser.add_argument('out_dir', type=str)
+    parser.add_argument('config_file', type=str)
+    args = parser.parse_args()
+
+    # parse config file
+    config_parser = configparser.RawConfigParser()
+    config_file_path = args.config_file
+    config_parser.read(config_file_path)
+
+    # set output log file
+    controller_name = config_parser.get('experiment', 'controller_name')
+    log_file = '%s_%s.log' % (controller_name, args.sample_name)
+    log_path = os.path.join(args.out_dir, log_file)
+    add_log_file(log_path, 'INFO')
+
+    # run simulation here
+    sample_name = args.sample_name
+    seed_file = args.seed_file
+    out_dir = args.out_dir
+    choices = {
+        IN_SILICO_OPTIMISE_TOPN: TopNSimulator(sample_name, seed_file, out_dir, controller_name, config_parser),
+        IN_SILICO_OPTIMISE_SMART_ROI: SmartROISimulator(sample_name, seed_file, out_dir, controller_name,
+                                                        config_parser),
+        IN_SILICO_OPTIMISE_WEIGHTED_DEW: WeightedDEWSimulator(sample_name, seed_file, out_dir, controller_name,
+                                                              config_parser),
+    }
+    sim = choices[controller_name]
+    sim.run()


### PR DESCRIPTION
Fixes for #195 

The codes to perform in-silico simulation of various controllers (namely SmartROI and WeightedDEW) are quite messy and scattered in different notebooks. I've put them all into a single file `scripts/in_silico_optimise.py` that can be easily run.

Usage:
```
$ python in_silico_optimise.py <sample_name> <seed_mzML> <output_folder> <config_file>
```
where:
- `<sample_name>` could be anything, e.g. 'QCA'
- `<seed_mzML>` and `<output_folder>` are the paths to the seed mzML and the output folder
- `<config_file>` is the path to the config files. Examples are given in `scripts/config/*.txt` for the experiments we did in the paper using the SmartROI and WeightedDEW controllers.

Notes:

Only 3 controllers are supported right now (those we use in the paper): TopN, SmartROI and WeightedDEW, although it shouldn't be hard to add more.

Scan times can be fixed in the config file, or if left blank, it will be computed from the seed file.

To save time, the script will try to run the controllers in parallel using ipcluster. If it fails, then it will run them serially.

Peak picking is done using MzMine2 only for now.

Still need to supply that `peak_sampler` object. That will go away once issue #46 is fixed.

Might be useful to slap some GUI on top of this, so other people can easily upload their own seed mzML file and run different controllers on it?