### PR TITLE
Added a task manager to manage the number of custom scans being sent

### DIFF
--- a/tests/test_mass_spec.py
+++ b/tests/test_mass_spec.py
@@ -1,0 +1,39 @@
+from loguru import logger
+
+from tests.conftest import MIN_MS1_INTENSITY, run_environment, \
+    check_non_empty_MS2, check_mzML, OUT_DIR, BEER_CHEMS, BEER_MIN_BOUND, BEER_MAX_BOUND
+from vimms.Common import POSITIVE, set_log_level_warning, set_log_level_debug
+from vimms.Controller import TopNController
+from vimms.Environment import Environment
+from vimms.MassSpec import IndependentMassSpectrometer, TaskManager
+
+
+class TestSimulatedMassSpec:
+    """
+    Tests the Top-N controller that does standard DDA Top-N fragmentation scans with the simulated mass spec class.
+    """
+
+    def test_mass_spec(self, fragscan_ps):
+        logger.info('Testing mass spec using the Top-N controller and QC beer chemicals')
+
+        isolation_width = 1
+        N = 10
+        rt_tol = 15
+        mz_tol = 10
+        ionisation_mode = POSITIVE
+
+        task_manager = TaskManager(buffer_size=3)
+        mass_spec = IndependentMassSpectrometer(ionisation_mode, BEER_CHEMS, fragscan_ps, task_manager=task_manager)
+        controller = TopNController(ionisation_mode, N, isolation_width, mz_tol, rt_tol, MIN_MS1_INTENSITY)
+
+        # create an environment to run both the mass spec and controller
+        env = Environment(mass_spec, controller, BEER_MIN_BOUND, BEER_MAX_BOUND, progress_bar=True)
+        # run_environment(env)
+        env.run()
+
+        # check that there is at least one non-empty MS2 scan
+        check_non_empty_MS2(controller)
+
+        # write simulated output to mzML file
+        filename = 'test_mass_spec.mzML'
+        check_mzML(env, OUT_DIR, filename)

--- a/vimms/Controller/base.py
+++ b/vimms/Controller/base.py
@@ -115,9 +115,11 @@ class Controller(object):
     def set_environment(self, env):
         self.environment = env
 
-    def handle_scan(self, scan, outgoing_queue_size, pending_tasks_size):
+    def handle_scan(self, scan, current_size, pending_size):
+        logger.debug('tasks to be sent = %d' % (current_size))
+        logger.debug('tasks sent but not received = %d' % (pending_size))
+
         # record every scan that we've received
-        logger.debug('Time %f Received %s' % (scan.rt, scan))
         self.scans[scan.ms_level].append(scan)
 
         # plot scan if there are peaks
@@ -127,20 +129,15 @@ class Controller(object):
         # we get an ms1 scan and it has some peaks AND all the pending tasks have been sent and processed AND
         # this ms1 scan is a custom scan we'd sent before (not a method scan)
         # then store it for fragmentation next time
-        self.last_scan = scan
         logger.debug(
             'scan.scan_id = %d, self.next_processed_scan_id = %d' % (scan.scan_id, self.next_processed_scan_id))
         if scan.scan_id == self.next_processed_scan_id:
             self.scan_to_process = scan
-            self.pending_tasks = pending_tasks_size
-            logger.debug('next processed scan %d has arrived' % self.next_processed_scan_id)
+            logger.debug('Next processed scan %d has arrived' % self.next_processed_scan_id)
         else:
             self.scan_to_process = None
-
-        logger.debug(
-            'outgoing_queue_size = %d, pending_tasks_size = %d' % (outgoing_queue_size, pending_tasks_size))
-        logger.debug('scan.scan_params = %s' % scan.scan_params)
         logger.debug('scan_to_process = %s' % self.scan_to_process)
+        logger.debug('scan.scan_params = %s' % scan.scan_params)
 
         # implemented by subclass
         new_tasks = self._process_scan(scan)

--- a/vimms/Controller/fullscan.py
+++ b/vimms/Controller/fullscan.py
@@ -29,8 +29,12 @@ class SimpleMs1Controller(Controller):
         super().__init__(params=params)
 
     def _process_scan(self, scan):
-        task = self.get_ms1_scan_params()
-        return [task]
+        if self.scan_to_process is not None:
+            task = self.get_ms1_scan_params()
+            self.current_task_id += 1
+            self.next_processed_scan_id = self.current_task_id
+            self.scan_to_process = None # set this scan as has been processed
+            return [task]
 
     def update_state_after_scan(self, last_scan):
         pass

--- a/vimms/Controller/misc.py
+++ b/vimms/Controller/misc.py
@@ -49,7 +49,7 @@ class FixedScansController(Controller):
         self.initial_task = schedule[0]  # used for sending the first scan
         self.tasks = schedule[1:]  # used for sending all the other scans
 
-    def handle_scan(self, scan, outgoing_queue_size, pending_tasks_size):
+    def handle_scan(self, scan, current_size, pending_size):
         # simply record every scan that we've received, but return no new tasks
         logger.debug('Time %f Received %s' % (scan.rt, scan))
         self.scans[scan.ms_level].append(scan)

--- a/vimms/MassSpec.py
+++ b/vimms/MassSpec.py
@@ -190,7 +190,7 @@ class IndependentMassSpectrometer(object):
         if params is None:
             try:
                 # get a scan params from the queue
-                params = self.processing_queue.pop(0)
+                params = self.get_params()
             except IndexError: # nothing in the queue
                 params = None
 
@@ -234,6 +234,20 @@ class IndependentMassSpectrometer(object):
         :return: None
         """
         self.processing_queue.append(param)
+
+    def get_params(self):
+        """
+        Retrieves a new set of scan parameters from the processing queue
+        :return: A new set of scan parameters from the queue if available,
+            otherwise it returns nothing (default scan set in actual MS)
+        """
+        # if the processing queue is empty, then just do the repeating scan
+        if len(self.processing_queue) == 0:
+            params = None
+        else:
+            # otherwise pop the parameter for the next scan from the queue
+            params = self.processing_queue.pop(0)
+        return params
 
     def fire_event(self, event_name, arg=None):
         """

--- a/vimms/MassSpec.py
+++ b/vimms/MassSpec.py
@@ -102,6 +102,101 @@ class FragmentationEvent(object):
     def __repr__(self):
         return 'MS%d FragmentationEvent for %s at %f' % (self.ms_level, self.chem, self.query_rt)
 
+
+class TaskManager(object):
+    """
+    A class to track how many new tasks (scan commands) that we can send, given the buffer size of the mass spec.
+    """
+    def __init__(self, buffer_size=5):
+        """
+        Initialises the task manager.
+        :param buffer_size: maximum buffer or queue size on the mass spec. At any point, this class will
+        ensure that there is not more than this number of tasks enqueued on the mass spec, see
+        https://github.com/thermofisherlsms/iapi/issues/22.
+        """
+        self.current_tasks = []
+        self.pending_tasks = []
+        self.buffer_size = buffer_size
+
+    def add_current(self, tasks):
+        """
+        Add to the list of current tasks (ready to send)
+        :param tasks: list of current tasks
+        :return: None
+        """
+        self.current_tasks.extend(tasks)
+
+    def add_pending(self, tasks):
+        """
+        Add to the list of pending tasks (sent but not received)
+        :param tasks: list of pending tasks
+        :return: None
+        """
+        self.pending_tasks.extend(tasks)
+
+    def remove_pending(self, completed_task):
+        """
+        Remove a completed task from the list of pending tasks
+        :param completed_task: a newly completed task
+        :return:
+        """
+        self.pending_tasks = [t for t in self.pending_tasks if t != completed_task]
+
+    def to_send(self):
+        """
+        Select current tasks that could be sent to the mass spec,
+        ensuring that buffer_size on the mass spec is not exceeded.
+        :return:
+        """
+        batch_size = self.buffer_size - self.pending_size()
+        batch = []
+        while self.current_size() > 0 and len(batch) < batch_size:
+            batch.append(self.pop_current())
+        return batch
+
+    def pop_current(self):
+        """
+        Remove the first current task (ready to send)
+        :return: a current task
+        """
+        return self.current_tasks.pop(0)
+
+    def pop_pending(self):
+        """
+        Remove the first pending task (sent but not received)
+        :return: a pending task
+        """
+        return self.pending_tasks.pop(0)
+
+    def peek_current(self):
+        """
+        Get the first current task (ready to send) without removing it
+        :return: a current task
+        """
+        return self.current_tasks[0]
+
+    def peek_pending(self):
+        """
+        Get the first pending task (sent but not received) without removing it
+        :return: a pending task
+        """
+        return self.pending_tasks[0]
+
+    def current_size(self):
+        """
+        Get the size of current tasks
+        :return: the size of current tasks
+        """
+        return len(self.current_tasks)
+
+    def pending_size(self):
+        """
+        Get the size of pending tasks
+        :return: the size of pending tasks
+        """
+        return len(self.pending_tasks)
+
+
 class IndependentMassSpectrometer(object):
     """
     A class that represents (synchronous) mass spectrometry process.
@@ -115,7 +210,7 @@ class IndependentMassSpectrometer(object):
 
     def __init__(self, ionisation_mode, chemicals, peak_sampler, mz_noise=None, intensity_noise=None, spike_noise=None,
                  isolation_transition_window='rectangular', isolation_transition_window_params=None,
-                 scan_duration_dict=DEFAULT_SCAN_TIME_DICT):
+                 scan_duration_dict=DEFAULT_SCAN_TIME_DICT, task_manager=None):
         """
         Creates a mass spec object.
         :param ionisation_mode: POSITIVE or NEGATIVE
@@ -130,7 +225,7 @@ class IndependentMassSpectrometer(object):
         self.time = 0
 
         # current task queue
-        self.processing_queue = []
+        self.task_manager = task_manager if task_manager is not None else TaskManager()
         self.environment = None
 
         self.events = Events((self.MS_SCAN_ARRIVED, self.ACQUISITION_STREAM_OPENING, self.ACQUISITION_STREAM_CLOSED,
@@ -188,52 +283,55 @@ class IndependentMassSpectrometer(object):
         """
         # if no params passed in, then try to get one from the queue
         if params is None:
-            try:
-                # get a scan params from the queue
-                params = self.get_params()
-            except IndexError: # nothing in the queue
-                params = None
+            # Get the next set of params from the outgoing tasks.
+            # This could return an empty list if there's nothing there.
+            params_list = self.get_params()
+        else:
+            logger.debug('Got an initial task from controller')
+            params_list = [params] # initial param passed from the controller
 
-        # if finally we have params, then make a scan
-        if params is not None:
-            scan = self._get_scan(self.time, params)
-            current_level = scan.ms_level
+        # Send params away. In the simulated case, no sending actually occurs,
+        # instead we just track these params we've sent by adding them to self.environment.pending_tasks
+        if len(params_list) > 0:
+            logger.debug('new tasks ready to send = %d' % len(params_list))
+            self.send_params(params_list)
 
-            # notify the controller that a new scan has been generated
-            # at this point, the MS_SCAN_ARRIVED event handler in the controller is called
-            # and the processing queue will be updated with new sets of scan parameters to do
-            self.fire_event(self.MS_SCAN_ARRIVED, scan)
+        # pick up the last param that has been sent and generate a new scan
+        new_scan = None
+        if self.task_manager.pending_size() > 0:
+            params = self.task_manager.pop_pending()
 
-            # sample scan duration and increase internal time
-            current_N = self.current_N
-            current_DEW = self.current_DEW
-            try:
-                next_scan_param = self.get_processing_queue()[0]
-            except IndexError:
-                next_scan_param = None
+            # Make scan using the param that has been sent
+            # Note that in the real mass spec, the scan generation likely won't happen
+            # immediately after the param is sent.
+            new_scan = self._get_scan(self.time, params)
 
-            current_scan_duration = self._increase_time(current_level, current_N, current_DEW,
-                                                        next_scan_param)
-            scan.scan_duration = current_scan_duration
+            # dispatch the generated scan to controller
+            self.dispatch_scan(new_scan)
+        return new_scan
 
-            # stores the updated value of N and DEW
-            self._store_next_N_DEW(next_scan_param)
-            return scan
+    def dispatch_scan(self, scan):
+        # notify the controller that a new scan has been generated
+        # at this point, the MS_SCAN_ARRIVED event handler in the controller is called
+        # and the processing queue will be updated with new sets of scan parameters to do
+        self.fire_event(self.MS_SCAN_ARRIVED, scan)
 
-    def get_processing_queue(self):
-        """
-        Returns the current processing queue
-        :return:
-        """
-        return self.processing_queue
+        # sample scan duration and increase internal time
+        current_N = self.current_N
+        current_DEW = self.current_DEW
+        try:
+            next_scan_param = self.task_manager.peek_current()
+        except IndexError:
+            next_scan_param = None
 
-    def add_to_processing_queue(self, param):
-        """
-        Adds a new scan parameters to the processing queue of scan parameters. Usually done by the controllers.
-        :param param: the scan parameters to add
-        :return: None
-        """
-        self.processing_queue.append(param)
+        current_level = scan.ms_level
+        current_scan_duration = self._increase_time(current_level, current_N, current_DEW,
+                                                    next_scan_param)
+        scan.scan_duration = current_scan_duration
+
+        # TODO: this is probably no longer necessary and can be removed as part of issue #46
+        # stores the updated value of N and DEW
+        self._store_next_N_DEW(next_scan_param)
 
     def get_params(self):
         """
@@ -241,13 +339,15 @@ class IndependentMassSpectrometer(object):
         :return: A new set of scan parameters from the queue if available,
             otherwise it returns nothing (default scan set in actual MS)
         """
-        # if the processing queue is empty, then just do the repeating scan
-        if len(self.processing_queue) == 0:
-            params = None
-        else:
-            # otherwise pop the parameter for the next scan from the queue
-            params = self.processing_queue.pop(0)
-        return params
+        params_list = self.task_manager.to_send()
+        logger.debug('Selected %d tasks to send' % (len(params_list)))
+        return params_list
+
+    def send_params(self, params_list):
+        # in the real IAPI mass spec, we would send these params to the instrument.
+        # but here we just store them in the list of pending tasks to be processed later
+        self.task_manager.add_pending(params_list)
+        logger.debug('Successfully sent %d tasks' % (len(params_list)))
 
     def fire_event(self, event_name, arg=None):
         """
@@ -324,7 +424,7 @@ class IndependentMassSpectrometer(object):
             current_scan_duration = tt
 
         self.time += current_scan_duration
-        logger.debug('Time %f Len(queue)=%d' % (self.time, len(self.processing_queue)))
+        logger.debug('scan_duration=%f time %f' % (current_scan_duration, self.time))
         return current_scan_duration
 
     def _sample_scan_duration(self, current_DEW, current_N, current_level, next_level):


### PR DESCRIPTION
Fixes for issue #199. 

The following PR https://github.com/sdrogers/vimms-fusion/pull/23 allows us to send multiple new custom scan commands after a scan has been received, but we need a way to manage the number of scans we're sending. According to what Thermo said:

> New custom scans can always be "sent" to the instrument, the instrument will enqueue them if it has space (I forget the size of the queue, but it is 10-100 in size about,). If it doesn't have the space, it will overwrite the oldest scan in the queue (i.e., it uses a circular buffer). I don't think there is user-visible message if that occurs, I know I had a log print in there to log when that happens.

To ensure that we stay within the limit of the queue, I've added a [`TaskManager`](https://github.com/sdrogers/vimms/blob/iss_199/vimms/MassSpec.py#L106-L197) class that tracks (1) `current_tasks`: the number of current outgoing tasks to be sent, and (2) `pending_tasks`: the number of pending tasks that have been sent but not received yet. 

Currently `current_tasks` is stored in a list, but it should be possible in the future to replace that with a priority queue, allowing higher priority tasks to be moved forward and sent first.