### PR TITLE
Fix coverage display and silence numpy warning

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-pytest --exitfirst --verbose --failed-first --cov=. --cov-report html
+pytest --exitfirst --verbose --failed-first --cov=. \
+       --cov-report term --cov-report html

--- a/vimms/Common.py
+++ b/vimms/Common.py
@@ -11,6 +11,21 @@ import zipfile
 
 from numba import njit
 import numpy as np
+import importlib
+import sys
+
+# ---------------------------------------------------------------------------
+# Compatibility fixes
+# ---------------------------------------------------------------------------
+# Older pickles in the wild may reference the module ``numpy.core.numeric``.
+# Importing this module directly now raises a ``DeprecationWarning`` in recent
+# NumPy versions.  To avoid emitting the warning when unpickling old objects,
+# alias ``numpy.core.numeric`` to ``numpy._core.numeric`` before any unpickling
+# happens.
+if 'numpy.core.numeric' not in sys.modules:
+    sys.modules['numpy.core.numeric'] = importlib.import_module(
+        'numpy._core.numeric'
+    )
 import requests
 from loguru import logger
 from tqdm.auto import tqdm


### PR DESCRIPTION
## Summary
- print text coverage from `run_tests.sh`
- silence deprecated `numpy.core.numeric` import when unpickling

## Testing
- `pytest tests/test_chemical_generation.py::TestDatabaseCreation::test_hmdb_creation --cov=. --cov-report term --cov-report html -q`

------
https://chatgpt.com/codex/tasks/task_e_683f981285988326807224cf6cdefb45