### PR TITLE
Add tests for chromatograms and peak picking helpers

### DIFF
--- a/tests/test_additional_modules.py
+++ b/tests/test_additional_modules.py
@@ -1,0 +1,124 @@
+import pytest
+import csv
+import numpy as np
+import pandas as pd
+from vimms.DIA import DiaWindows
+from vimms.Controller.targeted import Target, create_targets_from_toxid
+from vimms.Evaluation import Evaluator
+from vimms.Controller.misc import TaskFilter
+from vimms.Common import get_dda_scan_param, get_default_scan_params
+from vimms.scripts.check_ms2_matches import (
+    extract_msdial_spectrum, msdial_row_to_box, chem_to_spectral_record
+)
+
+
+# ---- DIA tests ----
+
+def test_dia_windows_basic_even():
+    ms1_mzs = np.linspace(0, 100, 11)
+    dw = DiaWindows(
+        ms1_mzs,
+        ms1_range=[(0, 100)],
+        dia_design="basic",
+        window_type="even",
+        kaufmann_design=None,
+        extra_bins=0,
+        num_windows=4,
+    )
+    internal = [-1, 25, 50, 75, 101]
+    for i in range(4):
+        assert dw.locations[i][0][0] == (
+            internal[i], internal[i + 1]
+        )
+
+
+def test_dia_windows_invalid():
+    with pytest.raises(ValueError):
+        DiaWindows(np.arange(5), [(0, 1)], "basic", "even", None, extra_bins=1, num_windows=2)
+
+
+# ---- Targeted tests ----
+
+def test_target_peak_and_active():
+    t = Target(100, 99, 101, 10, 20, name="A")
+    assert t.peak_in(100, 15)
+    assert not t.peak_in(102, 15)
+    mz_int = [(100, 1000)]
+    assert t.active(mz_int, 15, 500)
+    assert not t.active(mz_int, 5, 500)
+
+
+def test_target_str():
+    t = Target(100, 99, 101, 10, 20, name="A", adduct="[M+H]+")
+    assert "A[M+H]+" in str(t)
+
+
+def test_create_targets_from_toxid(tmp_path):
+    path = tmp_path / "toxid.csv"
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["Header"])
+        writer.writerow(["Index"])
+        writer.writerow([1, "Water", "H2O", "+", "x", 1.0, "", "", ""])
+    targets = create_targets_from_toxid(path, adducts_to_use=["[M+H]+"])
+    assert len(targets) == 1
+    t = targets[0]
+    assert t.metadata["name"] == "Water"
+    assert pytest.approx(t.from_rt) == 0.0
+    assert pytest.approx(t.to_rt) == 120.0
+
+
+# ---- Evaluation tests ----
+
+def test_new_window_interval():
+    i = Evaluator._new_window(5, 100, 2)
+    assert i.pt1.x == i.pt2.x == 5
+    assert i.pt1.y == 99
+    assert i.pt2.y == 101
+
+
+# ---- TaskFilter tests ----
+
+def _make_ms1(ms1_id):
+    sp = get_default_scan_params(scan_id=ms1_id)
+    return sp
+
+
+def _make_ms2(scan_id, precursor_id):
+    return get_dda_scan_param(100, 1e5, precursor_id, 1, 10, 10, scan_id=scan_id)
+
+
+def test_find_nearest_ms2():
+    tasks = [_make_ms1(1), _make_ms2(2, 1), _make_ms1(3)]
+    tf = TaskFilter(0.1, 0.1)
+    assert TaskFilter._find_nearest_ms2(0, tasks) == tasks[1]
+    assert TaskFilter._find_nearest_ms2(2, tasks) == tasks[1]
+    assert TaskFilter._find_nearest_ms2(1, tasks) is None
+
+
+# ---- check_ms2_matches utilities ----
+
+def test_extract_msdial_spectrum_and_box():
+    row = pd.Series({"MS/MS spectrum": "100:10 110:20"})
+    peaks = extract_msdial_spectrum(row, "MS/MS spectrum")
+    assert np.allclose(peaks[0], [100.0, 10.0])
+    box = msdial_row_to_box(100, 1, 2)
+    assert box.pt1.x == 60.0 and box.pt2.x == 120.0
+
+
+def test_chem_to_spectral_record():
+    class FakeFrag:
+        def __init__(self, mz, prop_ms2_mass, parent):
+            self.isotopes = [(mz, None, "MSN")]
+            self.prop_ms2_mass = prop_ms2_mass
+            self.parent = parent
+    class FakeChem:
+        def __init__(self):
+            self.isotopes = [(50.0, None, "MS1")]
+            self.rt = 10.0
+            self.max_intensity = 1000.0
+            self.children = [FakeFrag(60.0, 0.5, self)]
+    spec = chem_to_spectral_record(FakeChem())
+    assert spec.precursor_mz > 50.0
+    assert len(spec.peaks) == 1
+    assert spec.metadata["rt"] == 10.0

--- a/tests/test_box_utils.py
+++ b/tests/test_box_utils.py
@@ -1,0 +1,85 @@
+import numpy as np
+import pytest
+
+from vimms.Box import GenericBox, DictGrid, ArrayGrid
+from vimms.BoxVisualise import RGBAColour, FixedMap, InterpolationMap
+
+
+def test_generic_box_overlap_and_area():
+    b1 = GenericBox(0, 10, 0, 10)
+    b2 = GenericBox(5, 15, 5, 15)
+    assert b1.area() == 100
+    assert b1.overlaps_with_box(b2)
+    assert pytest.approx(b1.overlap_raw(b2)) == 25
+    union = b1.area() + b2.area() - 25
+    assert pytest.approx(b1.overlap_2(b2)) == 25 / union
+    assert pytest.approx(b1.overlap_3(b2)) == 0.25
+
+
+def test_generic_box_non_overlap_split():
+    b1 = GenericBox(0, 10, 0, 10)
+    b2 = GenericBox(5, 15, 5, 15)
+    splits = b1.non_overlap_split(b2)
+    assert len(splits) == 2
+    pts = sorted((s.pt1.x, s.pt2.x, s.pt1.y, s.pt2.y) for s in splits)
+    assert pts == [(0.0, 5.0, 0.0, 10.0), (5.0, 10.0, 0.0, 5.0)]
+
+
+def test_generic_box_apply_min_box_ppm_expands():
+    b = GenericBox(0, 1, 0, 1)
+    expanded = b.apply_min_box_ppm(xwidth=4e6)
+    assert expanded.pt1.x < b.pt1.x
+    assert expanded.pt2.x > b.pt2.x
+
+
+def _check_grid(Grid):
+    g = Grid(0, 10, 5, 0, 10, 5)
+    q = GenericBox(0, 10, 0, 10)
+    assert g.approx_non_overlap(q) == 1.0
+    b1 = GenericBox(0, 5, 0, 5)
+    g.register_box(b1)
+    assert np.isclose(g.approx_non_overlap(q), 5 / 9)
+    g.register_box(GenericBox(5, 10, 0, 5))
+    assert np.isclose(g.approx_non_overlap(q), 3 / 9)
+
+
+def test_dict_and_array_grid():
+    for grid in (DictGrid, ArrayGrid):
+        _check_grid(grid)
+
+
+def test_rgba_colour_operations():
+    c = RGBAColour.from_hexcode("#ff0000", A=0.5)
+    assert (c.R, c.G, c.B, c.A) == (255, 0, 0, 0.5)
+    assert c.to_hexcode() == "#ff0000"
+
+    other = RGBAColour(10, 20, 30, 0.5)
+    added = c + other
+    assert (added.R, added.G, added.B, added.A) == (265, 20, 30, 1.0)
+
+    scaled = other * 0.5
+    assert (scaled.R, scaled.G, scaled.B, scaled.A) == (5, 10, 15, 0.25)
+
+    bad = RGBAColour(300, -10, 260, 2)
+    bad.correct_bounds()
+    assert (bad.R, bad.G, bad.B, bad.A) == (255, 0, 255, 1.0)
+
+    inter = c.interpolate([RGBAColour(0, 0, 0, 0.0)], weights=[0.5, 0.5])
+    assert np.isclose(inter.R, 127.5)
+    assert np.isclose(inter.A, 0.25)
+
+
+def test_fixed_and_interpolation_map():
+    boxes = [GenericBox(0, 1, 0, 1), GenericBox(2, 3, 2, 3)]
+    fmap = FixedMap([RGBAColour(1, 1, 1), RGBAColour(2, 2, 2)])
+    cols = list(fmap.unique_colours(boxes))
+    assert cols[0][1].R == 1 and cols[1][1].R == 2
+
+    imap = InterpolationMap([RGBAColour(0, 0, 0), RGBAColour(100, 100, 100)])
+    cols = list(imap.assign_colours(boxes, lambda b: b.pt1.x, minm=0, maxm=2))
+    assert cols[0][1].R == 0
+    assert cols[1][1].R == 100
+
+    mid_box = GenericBox(0.5, 1.5, 0, 1)
+    mid_col = list(imap.assign_colours([mid_box], lambda b: b.pt1.x, minm=0, maxm=1))[0][1]
+    assert np.isclose(mid_col.R, 50.0)

--- a/tests/test_chromatograms_peakpicking.py
+++ b/tests/test_chromatograms_peakpicking.py
@@ -1,0 +1,66 @@
+import pytest
+import os
+import numpy as np
+from vimms.Chromatograms import EmpiricalChromatogram, ConstantChromatogram, FunctionalChromatogram
+from vimms.PeakPicking import count_boxes, format_output_path, MZMineParams
+
+
+def test_empirical_chromatogram_sort_and_normalise():
+    rts = np.array([2.0, 1.0, 3.0])
+    mzs = np.array([100.0, 101.0, 102.0])
+    ints = np.array([10.0, 30.0, 20.0])
+    chrom = EmpiricalChromatogram(rts, mzs, ints)
+    # rts should be sorted internally
+    assert np.all(np.diff(chrom.rts) >= 0)
+    # intensities normalised to 1
+    assert chrom.intensities.max() == 1.0
+    # relative intensity at first time point should match first sorted intensity
+    ri = chrom.get_relative_intensity(chrom.rts[0])
+    assert ri == chrom.intensities[0]
+
+
+def test_empirical_chromatogram_single_point():
+    chrom = EmpiricalChromatogram(np.array([5.0]), np.array([50.0]), np.array([5.0]))
+    # single point gets expanded into length-two arrays
+    assert len(chrom.rts) == 2
+    assert chrom.intensities[0] == chrom.intensities[1]
+
+
+def test_constant_chromatogram():
+    chrom = ConstantChromatogram()
+    assert chrom.get_relative_intensity(0.0) == 1.0
+    assert chrom.get_relative_mz(10.0) == 0.0
+    assert chrom._rt_match(-1.0)
+    assert chrom.get_apex_rt() == 0.0
+
+
+def test_functional_chromatogram_normal():
+    chrom = FunctionalChromatogram("normal", [0.0, 1.0])
+    # apex occurs at the midpoint of rt range
+    expected_apex = (chrom.max_rt - chrom.min_rt) / 2
+    assert np.isclose(chrom.get_apex_rt(), expected_apex)
+    assert chrom._rt_match(0.0)
+    # relative intensity at mean should be maximal
+    assert chrom.get_relative_intensity(expected_apex) == pytest.approx(1.0, rel=1e-3)
+
+
+def test_count_boxes(tmp_path):
+    path = tmp_path / "boxes.csv"
+    with open(path, "w") as f:
+        f.write("header\n")
+        f.write("1\n2\n3\n")
+    assert count_boxes(path) == 3
+
+
+def test_format_output_path(tmp_path):
+    out = format_output_path("TEST", tmp_path, "sample.csv")
+    assert out.endswith("sample_test_aligned.csv")
+    assert os.path.dirname(out) == str(tmp_path)
+
+    out = tmp_path / "aligned.csv"
+    with open(out, "w") as f:
+        f.write("file1.mzML filtered Peak Area,file2.mzML filtered Peak Area\n")
+    passed, _, _ = MZMineParams.check_files_match(["file1.mzML"], out)
+    passed2, _, _ = MZMineParams.check_files_match(["file1.mzML"], out, mode="exact")
+    assert passed
+    assert not passed2

--- a/tests/test_crp_noise.py
+++ b/tests/test_crp_noise.py
@@ -1,0 +1,70 @@
+import numpy as np
+
+from vimms.ChineseRestaurantProcess import discrete_draw, Restricted_Crp
+from vimms.Noise import (
+    trunc_normal,
+    GaussianPeakNoise,
+    GaussianPeakNoiseLevelSpecific,
+    UniformSpikeNoise,
+)
+
+
+def test_discrete_draw_deterministic():
+    np.random.seed(0)
+    result = discrete_draw([0.2, 0.8])
+    assert result == 1
+
+
+def test_restricted_crp_basic():
+    np.random.seed(1)
+    nxt, counts = Restricted_Crp(1, [1], [], 0)
+    assert nxt == 0
+    assert counts == [1]
+
+
+def test_restricted_crp_existing_counts():
+    np.random.seed(0)
+    nxt, counts = Restricted_Crp(1, [1], [0], 1)
+    assert nxt == 1
+    assert counts == [1, 1]
+
+
+def test_trunc_normal_positive():
+    np.random.seed(0)
+    val = trunc_normal(5, 1, False)
+    assert val > 0
+    np.random.seed(0)
+    log_val = trunc_normal(5, 1, True)
+    assert log_val > 0
+
+
+def test_gaussian_peak_noise():
+    np.random.seed(0)
+    noise = GaussianPeakNoise(1)
+    val = noise.get(10, 1)
+    assert np.isclose(val, 11.764052345967665)
+
+
+def test_gaussian_peak_noise_level_specific():
+    np.random.seed(0)
+    noise = GaussianPeakNoiseLevelSpecific({1: 1})
+    val_level1 = noise.get(10, 1)
+    val_level2 = noise.get(10, 2)
+    assert np.isclose(val_level1, 11.764052345967665)
+    assert val_level2 == 10
+
+
+def test_uniform_spike_noise_sampling():
+    np.random.seed(0)
+    noise = UniformSpikeNoise(density=0.5, max_val=10, min_val=5)
+    mzs, intensities = noise.sample(0, 10)
+    assert len(mzs) == len(intensities) == 5
+    assert np.all(mzs >= 0) and np.all(mzs <= 10)
+    assert np.all(intensities >= 5) and np.all(intensities <= 10)
+
+
+def test_uniform_spike_noise_bounds_override():
+    np.random.seed(0)
+    noise = UniformSpikeNoise(density=1, max_val=1, min_val=0, min_mz=5, max_mz=6)
+    mzs, _ = noise.sample(0, 10)
+    assert np.all(mzs >= 5) and np.all(mzs <= 6)

--- a/tests/test_feature_dsda.py
+++ b/tests/test_feature_dsda.py
@@ -1,0 +1,65 @@
+import zipfile
+import pandas as pd
+import numpy as np
+
+from vimms.FeatureExtraction import extract_hmdb_metabolite
+from vimms.DsDA import dsda_get_scan_params, create_dsda_schedule
+from vimms.Common import INITIAL_SCAN_ID
+
+
+def test_extract_hmdb_metabolite(tmp_path):
+    xml_content = """<?xml version='1.0' encoding='utf-8'?>
+<metabolites xmlns='http://www.hmdb.ca'>
+  <metabolite>
+    <name>Water</name>
+    <chemical_formula>H2O</chemical_formula>
+    <monisotopic_molecular_weight>18.0</monisotopic_molecular_weight>
+    <smiles>O</smiles>
+    <inchi>InChI=1S/H2O/h1H2</inchi>
+    <inchikey>Q2ZDBBJKTPGOMY-UHFFFAOYSA-N</inchikey>
+  </metabolite>
+</metabolites>
+"""
+    xml_path = tmp_path / "hmdb.xml"
+    xml_path.write_text(xml_content)
+    zip_path = tmp_path / "hmdb.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.write(xml_path, arcname="hmdb.xml")
+    compounds = extract_hmdb_metabolite(str(zip_path), delete=True)
+    assert not zip_path.exists()
+    assert len(compounds) == 1
+    c = compounds[0]
+    assert c.name == "Water"
+    assert c.chemical_formula == "H2O"
+    assert c.monisotopic_molecular_weight == "18.0"
+    assert c.smiles == "O"
+    assert c.inchi.startswith("InChI")
+    assert c.inchikey.startswith("Q2Z")
+
+
+def test_dsda_get_scan_params(tmp_path):
+    schedule = pd.DataFrame({"targetMass": [np.nan, 150.0, 200.0]})
+    template = pd.DataFrame({"type": ["ms", "msms", "msms"]})
+    sched_file = tmp_path / "sched.csv"
+    templ_file = tmp_path / "templ.csv"
+    schedule.to_csv(sched_file, index=False)
+    template.to_csv(templ_file, index=False)
+    scans = dsda_get_scan_params(sched_file, templ_file, 1.0, 0.1, 10)
+    assert len(scans) == 3
+    assert scans[0].get(scans[0].MS_LEVEL) == 1
+    assert scans[1].get(scans[1].MS_LEVEL) == 2
+    assert scans[1].get(scans[1].PRECURSOR_MZ)[0].precursor_scan_id == INITIAL_SCAN_ID
+
+
+def test_create_dsda_schedule(tmp_path):
+    class FakeMS:
+        scan_duration_dict = {1: 1.0, 2: 2.0}
+    # use a short max_rt so the schedule loop runs zero iterations
+    create_dsda_schedule(FakeMS, 1, 0, 0.5, tmp_path)
+    csv_file = tmp_path / "DsDA_Timing_schedule.csv"
+    assert csv_file.exists()
+    df = pd.read_csv(csv_file)
+    assert list(df.columns) == ["rt", "f", "type"]
+    # first row corresponds to min_rt and lm type
+    assert df.iloc[0]["rt"] == 0
+    assert df.iloc[0]["type"] == "lm"

--- a/tests/test_more_coverage.py
+++ b/tests/test_more_coverage.py
@@ -1,0 +1,85 @@
+import os
+import sys
+import runpy
+import numpy as np
+import pytest
+
+from vimms.Column import CleanColumn, LinearColumn
+from vimms.Controller.noise import ThresholdEstimator, IncreaseEstimator
+from vimms.scripts.openms_optimise_params import ParametersBuilder, TopNParameters
+from pathlib import Path
+import vimms
+
+remove_lines_path = Path(vimms.__file__).resolve().parent / 'scripts' / 'remove_lines.py'
+from vimms.MassSpecUtils import adduct_transformation
+from vimms.Utils import decimal_to_string
+
+
+class FakeChem:
+    def __init__(self, rt, apex):
+        self.rt = rt
+        self._apex = apex
+    def get_apex_rt(self):
+        return self._apex
+
+
+class FakeROI:
+    def __init__(self, intensities, apex):
+        self.intensity_list = intensities
+        self._apex = apex
+    def estimate_apex(self):
+        return self._apex
+
+
+def test_clean_column_no_noise():
+    chems = [FakeChem(i, i) for i in range(3)]
+    col = CleanColumn(chems)
+    new = col.get_dataset()
+    assert [c.rt for c in new] == [0, 1, 2]
+
+
+def test_linear_column_fixed_offsets():
+    chems = [FakeChem(0, a) for a in (0, 1, 2)]
+    lc = LinearColumn.from_fixed_offsets(chems, 0.0, 1.0, 2.0)
+    # offsets = intercept + linear * apex_rt
+    expected = [1.0 + 2.0 * a for a in (0, 1, 2)]
+    assert np.allclose(lc.offsets, expected)
+
+
+def test_linear_column_drift_fn():
+    roi = FakeROI([1, 2, 3], 10)
+    lc = LinearColumn.from_fixed_offsets([FakeChem(0, 0)], 0.0, 1.0, 1.0)
+    drift, extra = lc.drift_fn(roi, 0)
+    assert drift == pytest.approx(10 - (10 - 1.0) / 2)
+    assert extra == {}
+
+
+def test_threshold_and_increase_estimators():
+    roi = FakeROI([0, 5, 6, 7], 0)
+    t = ThresholdEstimator(intensity_threshold=5, count_threshold=2)
+    assert t.estimate_noise(roi) == 1.0
+    i = IncreaseEstimator(count_threshold=2)
+    assert i.estimate_noise(roi) == 1.0
+
+
+def test_parameters_builder_set_and_error():
+    pb = ParametersBuilder(TopNParameters)
+    pb.set('N', 20)
+    params = pb.build()
+    assert params.N == 20
+    with pytest.raises(ValueError):
+        pb.set('NOT_REAL', 1)
+
+
+def test_remove_lines_script(tmp_path, monkeypatch):
+    f = tmp_path / 'file.txt'
+    f.write_text('a\nb\nc\nd\ne\nf\n')
+    monkeypatch.setattr(sys, 'argv', ['remove_lines.py', str(f)])
+    runpy.run_path(remove_lines_path, run_name='__main__')
+    assert f.read_text().splitlines() == ['d', 'f']
+
+
+def test_decimal_to_string_and_adduct_transformation():
+    assert decimal_to_string(4.5) == '4'
+    assert decimal_to_string(4.567, 2) == '4.57'
+    assert adduct_transformation(100.0, 1.0, 2.0) == 102.0

--- a/tests/test_scripts_utils.py
+++ b/tests/test_scripts_utils.py
@@ -1,0 +1,56 @@
+import os
+from datetime import datetime
+
+import pytest
+
+import vimms.scripts.parse_txt as parse_txt
+import vimms.scripts.msdial_wrapper as msdial_wrapper
+
+
+def test_get_running_number():
+    assert parse_txt.get_running_number('abc runningNumber=123 xyz') == 123
+    assert parse_txt.get_running_number('no number here') == -1
+
+
+def test_get_time_parsing():
+    line = '[01:02:03.004] stuff'
+    t = parse_txt.get_time(line)
+    assert t == datetime.strptime('01:02:03.004', '%H:%M:%S.%f')
+
+
+def test_next_helpers():
+    lines = [
+        'a',
+        'Key = ScanType: Full',
+        'Key = StartTime = 0.5',
+        'Key = InjectTime = 0.05',
+    ]
+    assert parse_txt.get_next_ms_level(lines, 0) == 1
+    assert parse_txt.get_next_start_time(lines, 0) == 0.5
+    assert parse_txt.get_next_inject_time(lines, 0) == 0.05
+
+
+def test_extract_scan_sequence_simple():
+    lines = [
+        '[00:00:00.000] Info CanAcceptNextCustomScan',
+        '[00:00:01.000] Placing runningNumber=10001',
+        'Key = ScanType: Full',
+        '[00:00:02.000] Received runningNumber=10001',
+        'Key = StartTime = 0.5',
+        'Key = InjectTime = 0.05',
+    ]
+    seq = parse_txt.extract_scan_sequence(lines, start_no=10000)
+    assert len(seq) == 1
+    s = seq[0]
+    assert s.running_number == 10001
+    assert s.ms_level == 1
+    assert s.start_time == 0.5
+    assert s.inject_time == 0.05
+    assert (s.receive_time - s.send_time).total_seconds() == 1.0
+
+
+def test_get_path_in_folder(tmp_path):
+    result = msdial_wrapper.get_path_in_folder('file.mzML', '{}.msp', tmp_path)
+    assert result == os.path.join(tmp_path, 'file.msp')
+    result2 = msdial_wrapper.get_path_in_folder('a_temp_file.txt', None, tmp_path, remove_substring='_temp')
+    assert result2 == os.path.join(tmp_path, 'a_file.txt')

--- a/tests/test_utils_smiles_mgf.py
+++ b/tests/test_utils_smiles_mgf.py
@@ -1,0 +1,42 @@
+import tempfile
+
+import vimms.Utils as U
+
+
+def test_packline_appends():
+    out = []
+    returned = U.packline(out, 'hi')
+    assert returned is out
+    assert out == ['hi\n']
+    U.packline(out, 'there')
+    assert out == ['hi\n', 'there\n']
+
+
+def test_smiles_to_formula():
+    assert U.smiles_to_formula('O') == 'H2O'
+    assert U.smiles_to_formula('CCO') == 'C2H6O'
+    assert U.smiles_to_formula('C1/') is None
+
+
+def test_mgf_to_database(tmp_path):
+    mgf_text = """BEGIN IONS
+SPECTRUMID=1
+SMILES=O
+PEPMASS=100
+100 1
+END IONS
+BEGIN IONS
+SPECTRUMID=2
+SMILES=C1/
+PEPMASS=200
+110 5
+END IONS
+"""
+    mgf_file = tmp_path / 'file.mgf'
+    mgf_file.write_text(mgf_text)
+    db = U.mgf_to_database(mgf_file)
+    assert len(db) == 1
+    d = db[0]
+    assert d.name == '1'
+    assert d.chemical_formula == 'H2O'
+


### PR DESCRIPTION
## Summary
- cover chromatogram classes in `Chromatograms`
- exercise helper utilities in `PeakPicking`

## Testing
- `pytest tests/test_chromatograms_peakpicking.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f98eac9e08326ba41ef31323b368e