### PR TITLE
Add PyPI release workflow

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -1,0 +1,25 @@
+name: Publish Release to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Poetry
+        run: pip install poetry==2.1.3
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-root
+      - name: Build package
+        run: poetry build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Eager to start using ViMMS? Take advantage of these resources:
 - Our [Demo folder](https://github.com/glasgowcompbio/vimms/tree/master/demo) contains notebooks that demonstrate how to use the framework in a simulated environment.
 - For specific examples that accompany our publications, see the [Example folder](https://github.com/glasgowcompbio/vimms/tree/master/examples).
 - You can also find this [quick guide on how to get started using ViMMS](https://github.com/glasgowcompbio/vimms/blob/master/demo/guide_to_vimms/guide_to_vimms.ipynb).
+- For instructions on publishing a release to PyPI, see the [Release guide](docs/release.md).
 
 ## Development Setup
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,26 @@
+---
+nav_exclude: false
+---
+# Release Guide
+
+This repository uses GitHub Actions to automatically publish the `vimms` package to [PyPI](https://pypi.org/) whenever a GitHub release is published. Follow the steps below to prepare a new release.
+
+## 1. Configure Secrets
+
+1. Obtain a PyPI API token from your PyPI account.
+2. Add the token to the GitHub repository secrets as `PYPI_API_TOKEN`.
+
+The workflow uses this secret to authenticate with PyPI when uploading the package.
+
+## 2. Bump the Version
+
+Update the version number in `pyproject.toml` before creating a release. Commit and push the change to the default branch.
+
+## 3. Create a Release
+
+1. Tag the commit with the desired version and push the tag, or use GitHub's web interface to create a new release.
+2. Publishing the release triggers the `release-to-pypi` workflow. This workflow will:
+   - build the package with Poetry,
+   - upload the resulting files from the `dist/` directory to PyPI.
+
+If the upload succeeds, the package will be available on PyPI under the new version.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish to PyPI on release
- document how to publish a release
- link the new guide from the README

## Testing
- `pre-commit run --files README.md docs/release.md .github/workflows/release-to-pypi.yml`
- `pytest -q` *(fails: KeyboardInterrupt but reported 28 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684000d996f4832681e1dd963d3252ee