### PR TITLE
Fix RTD dev dependencies

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,3 +21,5 @@ formats: all
 python:
   install:
     - method: poetry
+      with:
+        - dev


### PR DESCRIPTION
## Summary
- install poetry dev group when building docs

## Testing
- `pre-commit run --files .readthedocs.yml`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840024b07e88326bb01e226c79f5192