### PR TITLE
Add join_align helper and tests

### DIFF
--- a/demo/untargeted/join_aligner.py
+++ b/demo/untargeted/join_aligner.py
@@ -1,0 +1,53 @@
+import pandas as pd
+from typing import List
+
+
+def join_align(peaks: pd.DataFrame, mz_tol: float, rt_tol: float) -> pd.DataFrame:
+    """Align peaks across samples.
+
+    Parameters
+    ----------
+    peaks: DataFrame
+        Input peaks with at least ``mz``, ``rt``, ``intensity`` and ``sample``
+        columns.
+    mz_tol: float
+        Absolute mass tolerance used when grouping peaks.
+    rt_tol: float
+        Retention time tolerance used when grouping peaks.
+
+    Returns
+    -------
+    DataFrame
+        Aligned intensity matrix with mean ``mz`` and ``rt`` for each group and
+        a column for each sample.
+    """
+    required = {"mz", "rt", "intensity", "sample"}
+    if not required.issubset(peaks.columns):
+        missing = required - set(peaks.columns)
+        raise ValueError(f"Missing columns: {', '.join(missing)}")
+
+    peaks = peaks.sort_values(["mz", "rt"]).reset_index(drop=True)
+
+    groups: List[dict] = []
+    for row in peaks.to_dict("records"):
+        assigned = False
+        for grp in groups:
+            if abs(row["mz"] - grp["mz"]) <= mz_tol and abs(row["rt"] - grp["rt"]) <= rt_tol:
+                grp["members"].append(row)
+                # update mean mz/rt
+                grp["mz"] = sum(p["mz"] for p in grp["members"]) / len(grp["members"])
+                grp["rt"] = sum(p["rt"] for p in grp["members"]) / len(grp["members"])
+                assigned = True
+                break
+        if not assigned:
+            groups.append({"mz": row["mz"], "rt": row["rt"], "members": [row]})
+
+    samples = sorted(peaks["sample"].unique())
+    aligned_rows = []
+    for grp in groups:
+        out = {"mz": grp["mz"], "rt": grp["rt"]}
+        for s in samples:
+            ints = [p["intensity"] for p in grp["members"] if p["sample"] == s]
+            out[s] = sum(ints) if ints else 0.0
+        aligned_rows.append(out)
+    return pd.DataFrame(aligned_rows)

--- a/demo/untargeted/plan.md
+++ b/demo/untargeted/plan.md
@@ -1,0 +1,4 @@
+# Untargeted demo plan
+
+- [x] Align peaks across samples with `join_align`
+- [ ] Visualise aligned intensity matrix

--- a/tests/test_untargeted_demo.py
+++ b/tests/test_untargeted_demo.py
@@ -1,0 +1,41 @@
+import pandas as pd
+from demo.untargeted.join_aligner import join_align
+
+
+def test_single_group():
+    df = pd.DataFrame(
+        {
+            "mz": [100.0, 100.01],
+            "rt": [1.0, 1.02],
+            "intensity": [10, 20],
+            "sample": ["A", "B"],
+        }
+    )
+    out = join_align(df, mz_tol=0.05, rt_tol=0.05)
+    assert len(out) == 1
+    row = out.iloc[0]
+    assert row["A"] == 10
+    assert row["B"] == 20
+
+
+def test_two_groups():
+    df = pd.DataFrame(
+        {
+            "mz": [100.0, 100.04, 100.5],
+            "rt": [1.0, 1.02, 1.01],
+            "intensity": [5, 7, 9],
+            "sample": ["A", "B", "A"],
+        }
+    )
+    out = join_align(df, mz_tol=0.05, rt_tol=0.05)
+    assert len(out) == 2
+    # group 0 should contain first two peaks
+    first = out.iloc[0]
+    second = out.iloc[1]
+    if first["A"] == 5:
+        assert first["B"] == 7
+        assert second["A"] == 9
+    else:
+        assert first["A"] == 9
+        assert second["A"] == 5
+        assert second["B"] == 7


### PR DESCRIPTION
## Summary
- implement `join_align` in `demo/untargeted/join_aligner.py`
- create unit tests covering grouping behaviour
- add short plan for the untargeted demo

## Testing
- `flake8 demo/untargeted/join_aligner.py tests/test_untargeted_demo.py`
- `pytest tests/test_untargeted_demo.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68470113359c8326b7f8537a046446aa