### PR TITLE
Add pipeline script

### DIFF
--- a/demo/untargeted/evaluation/__init__.py
+++ b/demo/untargeted/evaluation/__init__.py
@@ -1,0 +1,5 @@
+"""Evaluation utilities for the untargeted demo."""
+
+from .metrics import compute_group_metrics
+
+__all__ = ["compute_group_metrics"]

--- a/demo/untargeted/evaluation/metrics.py
+++ b/demo/untargeted/evaluation/metrics.py
@@ -1,0 +1,33 @@
+import pandas as pd
+from sklearn.metrics import adjusted_rand_score, pair_confusion_matrix
+
+
+def compute_group_metrics(
+    peaks: pd.DataFrame,
+    compound_col: str = "compound_id",
+    group_col: str = "group",
+) -> dict:
+    """Return alignment metrics comparing predicted groups to ground truth.
+
+    Parameters
+    ----------
+    peaks : pd.DataFrame
+        Table containing columns ``compound_col`` and ``group_col``.
+    compound_col : str, optional
+        Column giving ground truth compound identifiers.
+    group_col : str, optional
+        Column giving predicted alignment group labels.
+
+    Returns
+    -------
+    dict
+        Dictionary with ``precision``, ``recall``, ``f1`` and ``ari`` keys.
+    """
+    labels_true = peaks[compound_col].to_numpy()
+    labels_pred = peaks[group_col].to_numpy()
+    tn, fp, fn, tp = pair_confusion_matrix(labels_true, labels_pred).ravel()
+    precision = tp / (tp + fp) if tp + fp else 0.0
+    recall = tp / (tp + fn) if tp + fn else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if precision + recall else 0.0
+    ari = adjusted_rand_score(labels_true, labels_pred)
+    return {"precision": precision, "recall": recall, "f1": f1, "ari": ari}

--- a/demo/untargeted/join_aligner.py
+++ b/demo/untargeted/join_aligner.py
@@ -1,0 +1,65 @@
+import pandas as pd
+
+
+def join_align(
+    peaks: pd.DataFrame,
+    mz_tol: float,
+    rt_tol: float,
+    return_labels: bool = False,
+) -> pd.DataFrame:
+    """Align peaks across samples based on m/z and RT tolerances.
+
+    Parameters
+    ----------
+    peaks : pd.DataFrame
+        Table containing ``sample``, ``mz``, ``rt`` and ``intensity`` columns.
+    mz_tol : float
+        Absolute m/z tolerance for grouping peaks.
+    rt_tol : float
+        Absolute retention time tolerance for grouping peaks.
+    return_labels : bool, optional
+        If ``True``, also return the input peaks with a ``group`` column
+        describing the assigned alignment group.
+
+    Returns
+    -------
+    pd.DataFrame
+        An intensity table with groups as rows and samples as columns. If
+        ``return_labels`` is ``True`` a tuple ``(aligned, peaks)`` is returned
+        where ``peaks`` contains the assigned ``group`` for each row.
+    """
+    required = {"sample", "mz", "rt", "intensity"}
+    if not required <= set(peaks.columns):
+        raise ValueError(f"Input peaks must contain columns {required}")
+
+    peaks = peaks.copy().sort_values(["mz", "rt"]).reset_index(drop=True)
+    groups: list[dict] = []
+    group_ids: list[int] = [-1] * len(peaks)
+
+    for idx, row in peaks.iterrows():
+        assigned = False
+        for gid, g in enumerate(groups):
+            if abs(row["mz"] - g["mz"]) <= mz_tol and abs(row["rt"] - g["rt"]) <= rt_tol:
+                n = g["n"] + 1
+                g["mz"] = (g["mz"] * g["n"] + row["mz"]) / n
+                g["rt"] = (g["rt"] * g["n"] + row["rt"]) / n
+                g["n"] = n
+                group_ids[idx] = gid
+                assigned = True
+                break
+        if not assigned:
+            groups.append({"mz": row["mz"], "rt": row["rt"], "n": 1})
+            group_ids[idx] = len(groups) - 1
+
+    peaks["group"] = group_ids
+    aligned = peaks.pivot_table(
+        index="group",
+        columns="sample",
+        values="intensity",
+        aggfunc="max",
+        fill_value=0,
+    ).sort_index()
+
+    if return_labels:
+        return aligned, peaks
+    return aligned

--- a/demo/untargeted/peak_picking.py
+++ b/demo/untargeted/peak_picking.py
@@ -1,0 +1,43 @@
+import pandas as pd
+from pathlib import Path
+
+
+def peak_table_from_ground_truth(gt: pd.DataFrame) -> pd.DataFrame:
+    """Return a simple peak table derived from the ground truth.
+
+    Parameters
+    ----------
+    gt : pd.DataFrame
+        Ground truth table produced by :func:`generate_ground_truth_table`.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns ``sample``, ``mz``, ``rt`` and ``intensity``.
+    """
+    required = {"sample", "mz_apex", "rt_apex", "intensity"}
+    if not required <= set(gt.columns):
+        raise ValueError(f"Ground truth must contain columns {required}")
+    return gt.rename(columns={"mz_apex": "mz", "rt_apex": "rt"})[
+        ["sample", "mz", "rt", "intensity"]
+    ]
+
+
+def write_peak_table(gt_file: Path, out_file: Path) -> pd.DataFrame:
+    """Read ``gt_file`` and write the peak table to ``out_file``."""
+    gt = pd.read_csv(gt_file)
+    peaks = peak_table_from_ground_truth(gt)
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    peaks.to_csv(out_file, index=False)
+    return peaks
+
+
+def main() -> None:
+    """Entry point for the peak picking step."""
+    gt_file = Path("./out/ground_truth.csv")
+    out_file = Path("./out/peaks.csv")
+    write_peak_table(gt_file, out_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/untargeted/pipeline.py
+++ b/demo/untargeted/pipeline.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+from .generate_dataset import (
+    setup_simulation,
+    generate_mzml_files,
+    generate_ground_truth_table,
+    write_ground_truth_mgf,
+)
+from .peak_picking import peak_table_from_ground_truth
+from .join_aligner import join_align
+from .evaluation import compute_group_metrics
+
+
+def run_pipeline(
+    out_dir: Path = Path("./out"),
+    n_chemicals: int = 100,
+    n_samples_per_group: int = 5,
+    mz_tol: float = 0.01,
+    rt_tol: float = 0.5,
+    max_rt: int = 180,
+    top_n: int = 1,
+) -> dict:
+    """Run the full untargeted demo pipeline and return alignment metrics."""
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Simulate chemicals and dataset design
+    chemicals, design = setup_simulation(n_chemicals, n_samples_per_group)
+
+    # Generate mzML files
+    generate_mzml_files(chemicals, design, out_dir, max_rt=max_rt, top_n=top_n)
+
+    # Ground truth table and library
+    gt = generate_ground_truth_table(chemicals, design)
+    gt_file = out_dir / "ground_truth.csv"
+    gt.to_csv(gt_file, index=False)
+    write_ground_truth_mgf(chemicals, out_dir / "ground_truth.mgf")
+
+    # Peak picking from ground truth
+    peaks = peak_table_from_ground_truth(gt)
+    peaks_file = out_dir / "peaks.csv"
+    peaks.to_csv(peaks_file, index=False)
+
+    # Alignment
+    aligned, labeled = join_align(peaks, mz_tol, rt_tol, return_labels=True)
+    aligned.to_csv(out_dir / "aligned.csv")
+
+    # Join group labels back to ground truth for evaluation
+    gt_eval = gt[["sample", "compound_id", "mz_apex", "rt_apex", "intensity"]].rename(
+        columns={"mz_apex": "mz", "rt_apex": "rt"}
+    )
+    df_eval = labeled.merge(gt_eval, on=["sample", "mz", "rt", "intensity"], how="left")
+
+    metrics = compute_group_metrics(df_eval, compound_col="compound_id", group_col="group")
+
+    (out_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
+
+    return metrics
+
+
+def main() -> None:
+    """Command-line entry point for running the pipeline."""
+
+    metrics = run_pipeline()
+    print("Alignment metrics:")
+    for k, v in metrics.items():
+        print(f"{k}: {v:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/untargeted/plan.md
+++ b/demo/untargeted/plan.md
@@ -9,10 +9,10 @@ track progress.
 1. **Simulated Data Generation**
    - Create a Python script to generate 100 chemicals using `ChemicalMixtureCreator`.
    - Split chemicals into two groups (case/control) with 5 samples each.
-   - Use reasonable metabolomics ranges (e.g. m/z 100--1000, RT <3 min) with
-     chromatograms roughly 5 s wide (``sigma≈1``).
-   - Acquire data with Top‑1 DDA in positive mode including common adducts.
-   - Export mzML files, a ground‑truth table linking peaks to compounds, and a
+   - Use reasonable metabolomics ranges (e.g. m/z 100--1000, RT <3 min) with
+     chromatograms roughly 5 s wide (``sigma~1``).
+   - Acquire data with Top-1 DDA in positive mode including common adducts.
+   - Export mzML files, a ground   truth table linking peaks to compounds, and a
      simple MGF library of MS2 spectra.
    - **Status:** Completed (mzML, ground truth table, and MGF library generated)
 
@@ -20,12 +20,12 @@ track progress.
    - Since the chemicals are simulated, derive peak information directly from the
      ground truth and produce a table of peaks per sample (bounding box, apex m/z,
      RT, intensity, sample name, etc.).
-   - **Status:** Not started
+   - **Status:** Completed (`peak_picking.py` generates `peaks.csv`)
 
 3. **Alignment**
    - Implement a simple join aligner that merges peaks across samples to create
      an aligned feature table. Optionally use MZmine for comparison.
-   - **Status:** Not started
+   - **Status:** Completed (``join_align`` implemented in ``join_aligner.py``)
 
 4. **Grouping Related Peaks**
    - Cluster related peaks (e.g. isotopes/adducts) using a simple RT clustering
@@ -34,7 +34,14 @@ track progress.
    - **Status:** Not started
 
 5. **Identification**
-   - Match observed peaks to the ground‑truth MSP library to assess performance.
+   - Match observed peaks to the ground   truth MSP library to assess performance.
    - **Status:** Not started
 
-A main pipeline script will orchestrate these steps once they are implemented.
+6. **Evaluation**
+   - Measure alignment accuracy against the ground truth using metrics such as
+     precision, recall, F1 score and adjusted Rand index.
+   - **Status:** Completed (evaluated in `pipeline.py`)
+
+7. **Pipeline Script**
+   - Orchestrate all steps from data generation through evaluation.
+   - **Status:** Completed (`pipeline.py` chains the full workflow)

--- a/tests/test_untargeted_demo.py
+++ b/tests/test_untargeted_demo.py
@@ -8,6 +8,12 @@ from demo.untargeted.generate_dataset import (
     setup_simulation,
 )
 
+from demo.untargeted.join_aligner import join_align
+from demo.untargeted.evaluation import compute_group_metrics
+from demo.untargeted.peak_picking import peak_table_from_ground_truth
+from demo.untargeted.pipeline import run_pipeline
+import pandas as pd
+
 
 def test_generate_chemicals_length():
     chems = generate_chemicals(10)
@@ -49,3 +55,89 @@ def test_write_ground_truth_mgf(tmp_path):
     write_ground_truth_mgf(chems, out_file)
     text = out_file.read_text()
     assert text.startswith("BEGIN IONS")
+
+
+def test_join_align_groups_by_tolerances():
+    peaks = pd.DataFrame(
+        {
+            "sample": ["s1", "s1", "s2", "s3"],
+            "mz": [100.0, 105.0, 100.01, 200.0],
+            "rt": [1.0, 1.5, 1.01, 2.0],
+            "intensity": [10, 5, 20, 30],
+        }
+    )
+    aligned = join_align(peaks, mz_tol=0.02, rt_tol=0.05)
+    assert set(aligned.columns) == {"s1", "s2", "s3"}
+    assert len(aligned) == 3
+    assert aligned.loc[0, "s1"] == 10
+    assert aligned.loc[0, "s2"] == 20
+    assert aligned.loc[1, "s1"] == 5
+    assert aligned.loc[2, "s3"] == 30
+
+
+def test_join_align_handles_missing_samples():
+    peaks = pd.DataFrame(
+        {
+            "sample": ["s1", "s2"],
+            "mz": [50.0, 50.01],
+            "rt": [0.5, 0.49],
+            "intensity": [5, 15],
+        }
+    )
+    aligned = join_align(peaks, mz_tol=0.02, rt_tol=0.02)
+    assert len(aligned) == 1
+    assert aligned.loc[0, "s1"] == 5
+    assert aligned.loc[0, "s2"] == 15
+
+
+def test_compute_group_metrics_perfect():
+    df = pd.DataFrame({
+        "group": [0, 0, 1, 1],
+        "compound_id": [1, 1, 2, 2],
+    })
+    metrics = compute_group_metrics(df)
+    assert metrics["f1"] == 1.0
+    assert metrics["ari"] == 1.0
+
+
+def test_compute_group_metrics_imperfect():
+    df = pd.DataFrame({
+        "group": [0, 0, 1, 1],
+        "compound_id": [1, 2, 1, 2],
+    })
+    metrics = compute_group_metrics(df)
+    assert 0 <= metrics["precision"] < 1.0
+
+
+def test_peak_table_from_ground_truth():
+    gt = pd.DataFrame(
+        {
+            "sample": ["s1", "s2"],
+            "compound_id": [0, 1],
+            "mz_apex": [100.0, 200.0],
+            "rt_apex": [1.0, 2.0],
+            "intensity": [10, 20],
+            "mz_min": [99.9, 199.9],
+            "mz_max": [100.1, 200.1],
+            "rt_min": [0.9, 1.9],
+            "rt_max": [1.1, 2.1],
+        }
+    )
+    peaks = peak_table_from_ground_truth(gt)
+    assert set(peaks.columns) == {"sample", "mz", "rt", "intensity"}
+    assert len(peaks) == 2
+    assert peaks.loc[1, "rt"] == 2.0
+
+
+def test_run_pipeline(tmp_path):
+    metrics = run_pipeline(
+        out_dir=tmp_path,
+        n_chemicals=1,
+        n_samples_per_group=1,
+        mz_tol=0.02,
+        rt_tol=0.1,
+        max_rt=20,
+        top_n=1,
+    )
+    assert set(metrics) == {"precision", "recall", "f1", "ari"}
+    assert (tmp_path / "aligned.csv").is_file()


### PR DESCRIPTION
## Summary
- implement `run_pipeline` to chain the demo workflow
- mark evaluation completed and describe pipeline in the plan
- test the full pipeline on a tiny dataset

## Testing
- `poetry run flake8 demo/untargeted/pipeline.py tests/test_untargeted_demo.py --count --select=E9,F63,F7,F82 --show-source --statistics`
- `poetry run flake8 demo/untargeted/pipeline.py tests/test_untargeted_demo.py --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics`
- `poetry run pytest tests/test_untargeted_demo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6847131cfbec8326ad2635ec07dd0687