### PR TITLE
Refactor pipeline output handling

### DIFF
--- a/demo/untargeted/generate_dataset.py
+++ b/demo/untargeted/generate_dataset.py
@@ -8,7 +8,7 @@ truth table of the underlying peaks.
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from vimms.Common import POSITIVE, PROTON_MASS
 from vimms.Controller import TopNController
@@ -25,6 +25,16 @@ class ExperimentalDesign:
     """Simple container describing sample groups."""
 
     samples: Dict[str, List[str]]
+
+
+@dataclass
+class Dataset:
+    """Container describing input data for the pipeline."""
+
+    design: ExperimentalDesign
+    mzml_files: Dict[str, Path]
+    ground_truth: Optional[pd.DataFrame] = None
+    mgf_file: Optional[Path] = None
 
 
 def create_design(n_samples_per_group: int = 5) -> ExperimentalDesign:
@@ -182,20 +192,63 @@ def write_ground_truth_mgf(chemicals: list, out_file: Path) -> None:
             f.write("END IONS\n")
 
 
+def generate_synthetic_dataset(
+    out_dir: Path,
+    n_chemicals: int = 100,
+    n_samples_per_group: int = 5,
+    max_rt: int = 180,
+    top_n: int = 1,
+    use_rt_noise: bool = False,
+    noise_sd: float = 0.1,
+    intercept_params: tuple[float, float] = (0.0, 5.0),
+    linear_params: tuple[float, float] = (0.0, 0.001),
+) -> Dataset:
+    """Generate a synthetic dataset and return a :class:`Dataset` object."""
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    chemicals, design = setup_simulation(n_chemicals, n_samples_per_group)
+
+    column_params = None
+    if use_rt_noise:
+        column_params = {
+            "noise_sd": noise_sd,
+            "intercept_params": intercept_params,
+            "linear_params": linear_params,
+        }
+
+    sample_chems = generate_mzml_files(
+        chemicals,
+        design,
+        out_dir,
+        max_rt=max_rt,
+        top_n=top_n,
+        column_params=column_params,
+    )
+
+    gt = generate_ground_truth_table(
+        chemicals,
+        design,
+        per_sample_chems=sample_chems if use_rt_noise else None,
+    )
+    gt_file = out_dir / "ground_truth.csv"
+    gt.to_csv(gt_file, index=False)
+    mgf_file = out_dir / "ground_truth.mgf"
+    write_ground_truth_mgf(chemicals, mgf_file)
+
+    mzml_files = {
+        sample: out_dir / group / f"{sample}.mzML"
+        for group, samples in design.samples.items()
+        for sample in samples
+    }
+
+    return Dataset(design=design, mzml_files=mzml_files, ground_truth=gt, mgf_file=mgf_file)
+
+
 def main() -> None:
     """Entry point for dataset preparation."""
-
-    chemicals, design = setup_simulation()
-    out_dir = Path("./out")
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    print(f"Generated {len(chemicals)} chemicals")
-    for group, names in design.samples.items():
+    dataset = generate_synthetic_dataset(Path("./out"))
+    for group, names in dataset.design.samples.items():
         print(group, names)
-    generate_mzml_files(chemicals, design, out_dir)
-    gt = generate_ground_truth_table(chemicals, design)
-    gt.to_csv(out_dir / "ground_truth.csv", index=False)
-    write_ground_truth_mgf(chemicals, out_dir / "ground_truth.mgf")
 
 
 if __name__ == "__main__":

--- a/demo/untargeted/pipeline.py
+++ b/demo/untargeted/pipeline.py
@@ -1,16 +1,18 @@
-import json
 from pathlib import Path
 
-
-from .generate_dataset import (
-    setup_simulation,
-    generate_mzml_files,
-    generate_ground_truth_table,
-    write_ground_truth_mgf,
-)
-from .peak_picking import peak_table_from_ground_truth
+from .generate_dataset import Dataset, generate_synthetic_dataset
 from .join_aligner import join_align
-from .evaluation import compute_group_metrics
+from .processing import (
+    get_peak_data,
+    OutputWriter,
+    group_related_peaks,
+    identify_compounds,
+    annotate_spectra,
+    batch_normalize,
+    impute_missing_values,
+    compute_statistics,
+    generate_report,
+)
 
 
 def report_metrics(metrics):
@@ -21,93 +23,34 @@ def report_metrics(metrics):
         print(f"{key}: {value:.4f}")
 
 
-def run_pipeline(
-    out_dir=Path("./out"),
-    n_chemicals=100,
-    n_samples_per_group=5,
-    mz_tol=0.01,
-    rt_tol=0.5,
-    max_rt=180,
-    top_n=1,
-    use_rt_noise=False,
-    noise_sd=0.1,
-    intercept_params=(0.0, 5.0),
-    linear_params=(0.0, 0.001),
-):
-    """Run the full untargeted demo pipeline and return alignment metrics.
+def run_pipeline(dataset: Dataset, out_dir: Path, mz_tol: float = 0.01, rt_tol: float = 0.5) -> dict | None:
+    """Run the preprocessing pipeline on ``dataset`` and return metrics if available."""
 
-    Parameters
-    ----------
-    use_rt_noise:
-        Whether to apply retention time drift to each injection using a
-        ``SimulatedDriftModel``.
-    noise_sd:
-        Standard deviation of random noise added around the drift function.
-    intercept_params:
-        Mean and standard deviation of the intercept term (seconds).
-    linear_params:
-        Mean and standard deviation of the linear term.
-    """
+    writer = OutputWriter(out_dir)
 
-    out_dir.mkdir(parents=True, exist_ok=True)
+    if dataset.ground_truth is None:
+        raise ValueError("Ground truth is required for the demo pipeline")
 
-    # Simulate chemicals and dataset design
-    chemicals, design = setup_simulation(n_chemicals, n_samples_per_group)
+    peaks = get_peak_data(dataset.ground_truth)
 
-    column_params = None
-    if use_rt_noise:
-        column_params = {
-            "noise_sd": noise_sd,
-            "intercept_params": intercept_params,
-            "linear_params": linear_params,
-        }
-
-    # Generate mzML files
-    sample_chems = generate_mzml_files(
-        chemicals,
-        design,
-        out_dir,
-        max_rt=max_rt,
-        top_n=top_n,
-        column_params=column_params,
-    )
-
-    # Ground truth table and library
-    gt = generate_ground_truth_table(
-        chemicals,
-        design,
-        per_sample_chems=sample_chems if use_rt_noise else None,
-    )
-    gt_file = out_dir / "ground_truth.csv"
-    gt.to_csv(gt_file, index=False)
-    write_ground_truth_mgf(chemicals, out_dir / "ground_truth.mgf")
-
-    # Peak picking from ground truth
-    peaks = peak_table_from_ground_truth(gt)
-    peaks_file = out_dir / "peaks.csv"
-    peaks.to_csv(peaks_file, index=False)
-
-    # Alignment
     aligned, labeled = join_align(peaks, mz_tol, rt_tol, return_labels=True)
-    aligned.to_csv(out_dir / "aligned.csv")
 
-    # Join group labels back to ground truth for evaluation
-    gt_eval = gt[["sample", "compound_id", "mz_apex", "rt_apex", "intensity"]].rename(
-        columns={"mz_apex": "mz", "rt_apex": "rt"}
-    )
-    df_eval = labeled.merge(gt_eval, on=["sample", "mz", "rt", "intensity"], how="left")
+    grouped = group_related_peaks(aligned)
+    identified = identify_compounds(grouped, dataset.mgf_file)
+    annotated = annotate_spectra(identified, dataset.mgf_file)
+    normalized = batch_normalize(annotated, dataset.design)
+    _ = impute_missing_values(normalized)
 
-    metrics = compute_group_metrics(df_eval, compound_col="compound_id", group_col="group")
-
-    (out_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
-
+    metrics = compute_statistics(labeled, dataset)
+    writer.write_all(peaks=peaks, aligned=aligned, metrics=metrics)
+    _ = generate_report(metrics)
     return metrics
 
 
 def main() -> None:
     """Command-line entry point for running the pipeline."""
-
-    metrics = run_pipeline(use_rt_noise=True)
+    dataset = generate_synthetic_dataset(Path("./out"), use_rt_noise=True)
+    metrics = run_pipeline(dataset, Path("./out"))
     report_metrics(metrics)
 
 

--- a/demo/untargeted/pipeline.py
+++ b/demo/untargeted/pipeline.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from abc import ABC, abstractmethod
 
 from .generate_dataset import Dataset, generate_synthetic_dataset
 from .join_aligner import join_align
@@ -15,6 +16,56 @@ from .processing import (
 )
 
 
+class BasePipeline(ABC):
+    """Base class encapsulating preprocessing logic."""
+
+    def __init__(
+        self,
+        dataset: Dataset,
+        out_dir: Path,
+        mz_tol: float = 0.01,
+        rt_tol: float = 0.5,
+    ) -> None:
+        self.dataset = dataset
+        self.out_dir = out_dir
+        self.mz_tol = mz_tol
+        self.rt_tol = rt_tol
+        self.writer = OutputWriter(out_dir)
+
+    def run(self) -> dict | None:
+        """Run the preprocessing pipeline."""
+
+        peaks = self.get_peaks()
+        aligned, labeled = join_align(
+            peaks, self.mz_tol, self.rt_tol, return_labels=True
+        )
+
+        grouped = group_related_peaks(aligned)
+        identified = identify_compounds(grouped, self.dataset.mgf_file)
+        annotated = annotate_spectra(identified, self.dataset.mgf_file)
+        normalized = batch_normalize(annotated, self.dataset.design)
+        _ = impute_missing_values(normalized)
+
+        metrics = compute_statistics(labeled, self.dataset)
+        self.writer.write_all(peaks=peaks, aligned=aligned, metrics=metrics)
+        _ = generate_report(metrics)
+        return metrics
+
+    @abstractmethod
+    def get_peaks(self):
+        """Return the peak table for alignment."""
+
+
+class SyntheticPipeline(BasePipeline):
+    """Pipeline that expects ground-truth derived peaks."""
+
+    def get_peaks(self):
+        if self.dataset.ground_truth is None:
+            raise ValueError("Ground truth is required for the demo pipeline")
+        return get_peak_data(self.dataset.ground_truth)
+
+
+
 def report_metrics(metrics):
     """Print alignment metrics in a friendly format."""
 
@@ -23,28 +74,15 @@ def report_metrics(metrics):
         print(f"{key}: {value:.4f}")
 
 
-def run_pipeline(dataset: Dataset, out_dir: Path, mz_tol: float = 0.01, rt_tol: float = 0.5) -> dict | None:
-    """Run the preprocessing pipeline on ``dataset`` and return metrics if available."""
+def run_pipeline(
+    dataset: Dataset, out_dir: Path, mz_tol: float = 0.01, rt_tol: float = 0.5
+) -> dict | None:
+    """Convenience wrapper executing the synthetic pipeline."""
 
-    writer = OutputWriter(out_dir)
-
-    if dataset.ground_truth is None:
-        raise ValueError("Ground truth is required for the demo pipeline")
-
-    peaks = get_peak_data(dataset.ground_truth)
-
-    aligned, labeled = join_align(peaks, mz_tol, rt_tol, return_labels=True)
-
-    grouped = group_related_peaks(aligned)
-    identified = identify_compounds(grouped, dataset.mgf_file)
-    annotated = annotate_spectra(identified, dataset.mgf_file)
-    normalized = batch_normalize(annotated, dataset.design)
-    _ = impute_missing_values(normalized)
-
-    metrics = compute_statistics(labeled, dataset)
-    writer.write_all(peaks=peaks, aligned=aligned, metrics=metrics)
-    _ = generate_report(metrics)
-    return metrics
+    pipeline = SyntheticPipeline(
+        dataset=dataset, out_dir=out_dir, mz_tol=mz_tol, rt_tol=rt_tol
+    )
+    return pipeline.run()
 
 
 def main() -> None:

--- a/demo/untargeted/processing.py
+++ b/demo/untargeted/processing.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+"""Stub processing steps for the untargeted workflow."""
+
+from pathlib import Path
+import json
+import pandas as pd
+
+from .generate_dataset import Dataset, ExperimentalDesign
+from .evaluation import compute_group_metrics
+from .peak_picking import peak_table_from_ground_truth
+
+
+def get_peak_data(gt: pd.DataFrame, out_dir: Path | None = None) -> pd.DataFrame:
+    """Return peaks derived from ``gt`` and optionally write to ``out_dir``.
+
+    Parameters
+    ----------
+    gt:
+        Ground truth table describing the true peaks.
+    out_dir:
+        Directory where ``peaks.csv`` will be written when provided.
+
+    Returns
+    -------
+    pd.DataFrame
+        Peak table containing ``sample``, ``mz``, ``rt`` and ``intensity``.
+    """
+    peaks = peak_table_from_ground_truth(gt)
+    if out_dir is not None:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        peaks.to_csv(out_dir / "peaks.csv", index=False)
+    return peaks
+
+
+class OutputWriter:
+    """Utility to persist pipeline outputs to disk."""
+
+    def __init__(self, out_dir: Path) -> None:
+        self.out_dir = out_dir
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+
+    def write_all(
+        self,
+        peaks: pd.DataFrame | None = None,
+        aligned: pd.DataFrame | None = None,
+        metrics: dict | None = None,
+    ) -> None:
+        """Write provided outputs to :pyattr:`out_dir`."""
+
+        if peaks is not None:
+            peaks.to_csv(self.out_dir / "peaks.csv", index=False)
+        if aligned is not None:
+            aligned.to_csv(self.out_dir / "aligned.csv", index=False)
+        if metrics is not None:
+            (self.out_dir / "metrics.json").write_text(
+                json.dumps(metrics, indent=2)
+            )
+
+
+def group_related_peaks(aligned: pd.DataFrame) -> pd.DataFrame:
+    """Group isotopes and adducts together.
+
+    Parameters
+    ----------
+    aligned:
+        Aligned feature table with sample intensities.
+
+    Returns
+    -------
+    pd.DataFrame
+        Table of grouped peaks. Currently returned unchanged.
+    """
+    return aligned
+
+
+def identify_compounds(
+    grouped: pd.DataFrame, library_file: Path | None = None
+) -> pd.DataFrame:
+    """Identify compounds by matching grouped peaks to a library.
+
+    Parameters
+    ----------
+    grouped:
+        Peak table after grouping related peaks.
+    library_file:
+        Optional path to an MGF or MSP library for matching.
+
+    Returns
+    -------
+    pd.DataFrame
+        Peak table with identification columns added. Returned unchanged for now.
+    """
+    return grouped
+
+
+def annotate_spectra(
+    identified: pd.DataFrame, library_file: Path | None = None
+) -> pd.DataFrame:
+    """Add spectral annotations to identified features.
+
+    Parameters
+    ----------
+    identified:
+        Peak table containing compound identifications.
+    library_file:
+        Optional path to a spectral library.
+
+    Returns
+    -------
+    pd.DataFrame
+        Annotated peak table. Returned unchanged for now.
+    """
+    return identified
+
+
+def batch_normalize(peaks: pd.DataFrame, design: ExperimentalDesign) -> pd.DataFrame:
+    """Correct systematic effects between sample groups or batches.
+
+    Parameters
+    ----------
+    peaks:
+        Table of peak intensities.
+    design:
+        Experimental design describing sample groups.
+
+    Returns
+    -------
+    pd.DataFrame
+        Normalized peak table. Returned unchanged for now.
+    """
+    return peaks
+
+
+def impute_missing_values(peaks: pd.DataFrame) -> pd.DataFrame:
+    """Fill in missing intensity values.
+
+    Parameters
+    ----------
+    peaks:
+        Table of peak intensities.
+
+    Returns
+    -------
+    pd.DataFrame
+        Peak table with missing values imputed. Returned unchanged for now.
+    """
+    return peaks
+
+
+def compute_statistics(labeled: pd.DataFrame, dataset: Dataset) -> dict:
+    """Compute evaluation metrics for the aligned peaks.
+
+    Parameters
+    ----------
+    labeled:
+        Peak-level table with grouping labels from the aligner.
+    dataset:
+        Dataset object containing the ground-truth table.
+
+    Returns
+    -------
+    dict
+        Dictionary of computed metrics. Empty if ground truth is unavailable.
+    """
+    if dataset.ground_truth is None:
+        return {}
+
+    gt_eval = dataset.ground_truth[
+        ["sample", "compound_id", "mz_apex", "rt_apex", "intensity"]
+    ].rename(columns={"mz_apex": "mz", "rt_apex": "rt"})
+    df_eval = labeled.merge(
+        gt_eval, on=["sample", "mz", "rt", "intensity"], how="left"
+    )
+    metrics = compute_group_metrics(df_eval, compound_col="compound_id", group_col="group")
+    return metrics
+
+
+def generate_report(metrics: dict) -> str:
+    """Return a JSON report summarizing ``metrics``."""
+
+    return json.dumps(metrics, indent=2)

--- a/tests/test_untargeted_demo.py
+++ b/tests/test_untargeted_demo.py
@@ -6,6 +6,7 @@ from demo.untargeted.generate_dataset import (
     generate_ground_truth_table,
     write_ground_truth_mgf,
     setup_simulation,
+    generate_synthetic_dataset,
 )
 
 from demo.untargeted.join_aligner import join_align
@@ -130,14 +131,13 @@ def test_peak_table_from_ground_truth():
 
 
 def test_run_pipeline(tmp_path):
-    metrics = run_pipeline(
-        out_dir=tmp_path,
+    dataset = generate_synthetic_dataset(
+        tmp_path,
         n_chemicals=1,
         n_samples_per_group=1,
-        mz_tol=0.02,
-        rt_tol=0.1,
         max_rt=20,
         top_n=1,
     )
+    metrics = run_pipeline(dataset, tmp_path, mz_tol=0.02, rt_tol=0.1)
     assert set(metrics) == {"precision", "recall", "f1", "ari"}
     assert (tmp_path / "aligned.csv").is_file()


### PR DESCRIPTION
## Summary
- add `get_peak_data` helper
- centralize output saving with new `OutputWriter`
- update pipeline to use the helper and writer

## Testing
- `poetry run flake8 . --exclude=.venv --count --select=E9,F63,F7,F82 --show-source --statistics`
- `poetry run flake8 . --exclude=.venv --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics`
- `poetry run pytest tests/test_untargeted_demo.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6848915747608326917623a6957337ac