### PR TITLE
Make heavy dependencies optional

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4,9 +4,10 @@
 name = "alembic"
 version = "1.16.1"
 description = "A database migration tool for SQLAlchemy."
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"optimize\""
 files = [
     {file = "alembic-1.16.1-py3-none-any.whl", hash = "sha256:0cdd48acada30d93aa1035767d67dff25702f8de74d7c3919f2e8492c8db2e67"},
     {file = "alembic-1.16.1.tar.gz", hash = "sha256:43d37ba24b3d17bc1eb1024fe0f51cd1dc95aeb5464594a02c6bb9ca9864bfa4"},
@@ -49,11 +50,11 @@ description = "Disable App Nap on macOS >= 10.9"
 optional = false
 python-versions = ">=3.6"
 groups = ["main", "dev"]
-markers = "platform_system == \"Darwin\""
 files = [
     {file = "appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c"},
     {file = "appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee"},
 ]
+markers = {main = "extra == \"parallel\" and platform_system == \"Darwin\"", dev = "platform_system == \"Darwin\""}
 
 [[package]]
 name = "argon2-cffi"
@@ -139,6 +140,7 @@ files = [
     {file = "asttokens-3.0.0-py3-none-any.whl", hash = "sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2"},
     {file = "asttokens-3.0.0.tar.gz", hash = "sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [package.extras]
 astroid = ["astroid (>=2,<4)"]
@@ -381,7 +383,7 @@ files = [
     {file = "cffi-1.17.1-cp39-cp39-win_amd64.whl", hash = "sha256:d016c76bdd850f3c626af19b0542c9677ba156e4ee4fccfdd7848803533ef662"},
     {file = "cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824"},
 ]
-markers = {main = "implementation_name == \"pypy\""}
+markers = {main = "extra == \"parallel\" and implementation_name == \"pypy\""}
 
 [package.dependencies]
 pycparser = "*"
@@ -522,19 +524,20 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["main", "dev"]
+markers = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\" or platform_system == \"Windows\""}
 
 [[package]]
 name = "colorlog"
 version = "6.9.0"
 description = "Add colours to the output of Python's logging module."
-optional = false
+optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"optimize\""
 files = [
     {file = "colorlog-6.9.0-py3-none-any.whl", hash = "sha256:5906e71acd67cb07a71e779c47c4bcb45fb8c2993eebe9e5adcd6a6f1b283eff"},
     {file = "colorlog-6.9.0.tar.gz", hash = "sha256:bfba54a1b93b94f54e1f4fe48395725a3d92fd2a4af702f6bd70946bdc0c6ac2"},
@@ -557,6 +560,7 @@ files = [
     {file = "comm-0.2.2-py3-none-any.whl", hash = "sha256:e6fb86cb70ff661ee8c9c14e7d36d6de3b4066f1441be4063df9c5009f0a64d3"},
     {file = "comm-0.2.2.tar.gz", hash = "sha256:3fd7a84065306e07bea1773df6eb8282de51ba82f77c72f9c85716ab11fe980e"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [package.dependencies]
 traitlets = ">=4"
@@ -772,6 +776,7 @@ files = [
     {file = "debugpy-1.8.14-py2.py3-none-any.whl", hash = "sha256:5cd9a579d553b6cb9759a7908a41988ee6280b961f24f63336835d9418216a20"},
     {file = "debugpy-1.8.14.tar.gz", hash = "sha256:7cd287184318416850aa8b60ac90105837bb1e59531898c07569d197d2ed5322"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [[package]]
 name = "decorator"
@@ -784,6 +789,7 @@ files = [
     {file = "decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a"},
     {file = "decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [[package]]
 name = "defusedxml"
@@ -820,6 +826,7 @@ files = [
     {file = "entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f"},
     {file = "entrypoints-0.4.tar.gz", hash = "sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [[package]]
 name = "events"
@@ -843,6 +850,7 @@ files = [
     {file = "executing-2.2.0-py2.py3-none-any.whl", hash = "sha256:11387150cad388d62750327a53d3339fad4888b39a6fe233c3afbb54ecffd3aa"},
     {file = "executing-2.2.0.tar.gz", hash = "sha256:5d108c028108fe2551d1a7b2e8b713341e2cb4fc0aa7dcf966fa4327a5226755"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [package.extras]
 tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipython", "littleutils", "pytest", "rich ; python_version >= \"3.11\""]
@@ -1188,6 +1196,7 @@ files = [
     {file = "ipykernel-6.29.5-py3-none-any.whl", hash = "sha256:afdb66ba5aa354b09b91379bac28ae4afebbb30e8b39510c9690afb7a10421b5"},
     {file = "ipykernel-6.29.5.tar.gz", hash = "sha256:f093a22c4a40f8828f8e330a9c297cb93dcab13bd9678ded6de8e5cf81c56215"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [package.dependencies]
 appnope = {version = "*", markers = "platform_system == \"Darwin\""}
@@ -1215,9 +1224,10 @@ test = ["flaky", "ipyparallel", "pre-commit", "pytest (>=7.0)", "pytest-asyncio 
 name = "ipyparallel"
 version = "9.0.1"
 description = "Interactive Parallel Computing with IPython"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"parallel\""
 files = [
     {file = "ipyparallel-9.0.1-py3-none-any.whl", hash = "sha256:cc0702e26af416a1c35c73eb6dbc3a6a2c49417cb24dda4511be85c9fe87ea64"},
     {file = "ipyparallel-9.0.1.tar.gz", hash = "sha256:2e592cad2200c5a94fbbff639bff36e6ec9122f34b36b2fc6b4d678d9e98f29c"},
@@ -1254,6 +1264,7 @@ files = [
     {file = "ipython-9.3.0-py3-none-any.whl", hash = "sha256:1a0b6dd9221a1f5dddf725b57ac0cb6fddc7b5f470576231ae9162b9b3455a04"},
     {file = "ipython-9.3.0.tar.gz", hash = "sha256:79eb896f9f23f50ad16c3bc205f686f6e030ad246cc309c6279a242b14afe9d8"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
@@ -1287,6 +1298,7 @@ files = [
     {file = "ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c"},
     {file = "ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [package.dependencies]
 pygments = "*"
@@ -1339,6 +1351,7 @@ files = [
     {file = "jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9"},
     {file = "jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [package.dependencies]
 parso = ">=0.8.4,<0.9.0"
@@ -1480,6 +1493,7 @@ files = [
     {file = "jupyter_client-7.4.9-py3-none-any.whl", hash = "sha256:214668aaea208195f4c13d28eb272ba79f945fc0cf3f11c7092c20b2ca1980e7"},
     {file = "jupyter_client-7.4.9.tar.gz", hash = "sha256:52be28e04171f07aed8f20e1616a5a552ab9fee9cbbe6c1896ae170c3880d392"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [package.dependencies]
 entrypoints = "*"
@@ -1505,6 +1519,7 @@ files = [
     {file = "jupyter_core-5.8.1-py3-none-any.whl", hash = "sha256:c28d268fc90fb53f1338ded2eb410704c5449a358406e8a948b75706e24863d0"},
     {file = "jupyter_core-5.8.1.tar.gz", hash = "sha256:0a5f9706f70e64786b75acba995988915ebd4601c8a52e534a40b51c95f59941"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [package.dependencies]
 platformdirs = ">=2.5"
@@ -1991,9 +2006,10 @@ source = ["Cython (>=3.0.11,<3.1.0)"]
 name = "mako"
 version = "1.3.10"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"optimize\""
 files = [
     {file = "mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59"},
     {file = "mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28"},
@@ -2093,6 +2109,7 @@ files = [
     {file = "MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:6e296a513ca3d94054c2c881cc913116e90fd030ad1c656b3869762b754f5f8a"},
     {file = "markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0"},
 ]
+markers = {main = "extra == \"optimize\""}
 
 [[package]]
 name = "mass-spec-utils"
@@ -2183,6 +2200,7 @@ files = [
     {file = "matplotlib_inline-0.1.7-py3-none-any.whl", hash = "sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca"},
     {file = "matplotlib_inline-0.1.7.tar.gz", hash = "sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [package.dependencies]
 traitlets = "*"
@@ -2345,9 +2363,10 @@ files = [
 name = "narwhals"
 version = "1.41.0"
 description = "Extremely lightweight compatibility layer between dataframe libraries"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"visual\""
 files = [
     {file = "narwhals-1.41.0-py3-none-any.whl", hash = "sha256:d958336b40952e4c4b7aeef259a7074851da0800cf902186a58f2faeff97be02"},
     {file = "narwhals-1.41.0.tar.gz", hash = "sha256:0ab2e5a1757a19b071e37ca74b53b0b5426789321d68939738337dfddea629b5"},
@@ -2459,6 +2478,7 @@ files = [
     {file = "nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c"},
     {file = "nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [[package]]
 name = "networkx"
@@ -2635,9 +2655,10 @@ files = [
 name = "optuna"
 version = "4.3.0"
 description = "A hyperparameter optimization framework"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"optimize\""
 files = [
     {file = "optuna-4.3.0-py3-none-any.whl", hash = "sha256:0ea1a01c99c09cbdf3e2dcd9af01dea86778d9fa20ca26f0238a98e7462d8dcb"},
     {file = "optuna-4.3.0.tar.gz", hash = "sha256:b3866842a84bc0bbb9906363bd846cfc39d09d3196265354bfdfda6a2f123b84"},
@@ -2792,6 +2813,7 @@ files = [
     {file = "parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18"},
     {file = "parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [package.extras]
 qa = ["flake8 (==5.0.4)", "mypy (==0.971)", "types-setuptools (==67.2.0.1)"]
@@ -2849,11 +2871,11 @@ description = "Pexpect allows easy control of interactive console applications."
 optional = false
 python-versions = "*"
 groups = ["main", "dev"]
-markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
     {file = "pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"},
 ]
+markers = {main = "extra == \"parallel\" and sys_platform != \"win32\" and sys_platform != \"emscripten\"", dev = "sys_platform != \"win32\" and sys_platform != \"emscripten\""}
 
 [package.dependencies]
 ptyprocess = ">=0.5"
@@ -2969,6 +2991,7 @@ files = [
     {file = "platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4"},
     {file = "platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [package.extras]
 docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
@@ -2979,9 +3002,10 @@ type = ["mypy (>=1.14.1)"]
 name = "plotly"
 version = "6.1.2"
 description = "An open-source interactive data visualization library for Python"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"visual\""
 files = [
     {file = "plotly-6.1.2-py3-none-any.whl", hash = "sha256:f1548a8ed9158d59e03d7fed548c7db5549f3130d9ae19293c8638c202648f6d"},
     {file = "plotly-6.1.2.tar.gz", hash = "sha256:4fdaa228926ba3e3a213f4d1713287e69dcad1a7e66cf2025bd7d7026d5014b4"},
@@ -3057,6 +3081,7 @@ files = [
     {file = "prompt_toolkit-3.0.51-py3-none-any.whl", hash = "sha256:52742911fde84e2d423e2f9a4cf1de7d7ac4e51958f648d9540e0fb8db077b07"},
     {file = "prompt_toolkit-3.0.51.tar.gz", hash = "sha256:931a162e3b27fc90c86f1b48bb1fb2c528c2761475e57c9c06de13311c7b54ed"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [package.dependencies]
 wcwidth = "*"
@@ -3103,6 +3128,7 @@ files = [
     {file = "psutil-7.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:4cf3d4eb1aa9b348dec30105c55cd9b7d4629285735a102beb4441e38db90553"},
     {file = "psutil-7.0.0.tar.gz", hash = "sha256:7be9c3eba38beccb6495ea33afd982a44074b78f28c434a1f51cc07fd315c456"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [package.extras]
 dev = ["abi3audit", "black (==24.10.0)", "check-manifest", "coverage", "packaging", "pylint", "pyperf", "pypinfo", "pytest", "pytest-cov", "pytest-xdist", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "virtualenv", "vulture", "wheel"]
@@ -3119,7 +3145,7 @@ files = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
     {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
 ]
-markers = {main = "sys_platform != \"win32\" and sys_platform != \"emscripten\"", dev = "sys_platform != \"win32\" and sys_platform != \"emscripten\" or os_name != \"nt\""}
+markers = {main = "extra == \"parallel\" and sys_platform != \"win32\" and sys_platform != \"emscripten\"", dev = "sys_platform != \"win32\" and sys_platform != \"emscripten\" or os_name != \"nt\""}
 
 [[package]]
 name = "pure-eval"
@@ -3132,6 +3158,7 @@ files = [
     {file = "pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0"},
     {file = "pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [package.extras]
 tests = ["pytest"]
@@ -3159,7 +3186,7 @@ files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
 ]
-markers = {main = "implementation_name == \"pypy\""}
+markers = {main = "extra == \"parallel\" and implementation_name == \"pypy\""}
 
 [[package]]
 name = "pyflakes"
@@ -3184,6 +3211,7 @@ files = [
     {file = "pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"},
     {file = "pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
@@ -3350,7 +3378,6 @@ description = "Python for Window Extensions"
 optional = false
 python-versions = "*"
 groups = ["main", "dev"]
-markers = "sys_platform == \"win32\" and platform_python_implementation != \"PyPy\""
 files = [
     {file = "pywin32-310-cp310-cp310-win32.whl", hash = "sha256:6dd97011efc8bf51d6793a82292419eba2c71cf8e7250cfac03bba284454abc1"},
     {file = "pywin32-310-cp310-cp310-win_amd64.whl", hash = "sha256:c3e78706e4229b915a0821941a84e7ef420bf2b77e08c9dae3c76fd03fd2ae3d"},
@@ -3369,6 +3396,7 @@ files = [
     {file = "pywin32-310-cp39-cp39-win32.whl", hash = "sha256:851c8d927af0d879221e616ae1f66145253537bbdd321a77e8ef701b443a9a1a"},
     {file = "pywin32-310-cp39-cp39-win_amd64.whl", hash = "sha256:96867217335559ac619f00ad70e513c0fcf84b8a3af9fc2bba3b59b97da70475"},
 ]
+markers = {main = "sys_platform == \"win32\" and platform_python_implementation != \"PyPy\" and extra == \"parallel\"", dev = "sys_platform == \"win32\" and platform_python_implementation != \"PyPy\""}
 
 [[package]]
 name = "pywinpty"
@@ -3450,6 +3478,7 @@ files = [
     {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
     {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
 ]
+markers = {main = "extra == \"optimize\""}
 
 [[package]]
 name = "pyyaml-env-tag"
@@ -3568,6 +3597,7 @@ files = [
     {file = "pyzmq-26.4.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:49b6ca2e625b46f499fb081aaf7819a177f41eeb555acb05758aa97f4f95d147"},
     {file = "pyzmq-26.4.0.tar.gz", hash = "sha256:4bd13f85f80962f91a651a7356fe0472791a5f7a92f227822b5acf44795c626d"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [package.dependencies]
 cffi = {version = "*", markers = "implementation_name == \"pypy\""}
@@ -3992,9 +4022,10 @@ test = ["Cython", "array-api-strict (>=2.0,<2.1.1)", "asv", "gmpy2", "hypothesis
 name = "seaborn"
 version = "0.13.2"
 description = "Statistical data visualization"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"visual\""
 files = [
     {file = "seaborn-0.13.2-py3-none-any.whl", hash = "sha256:636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987"},
     {file = "seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7"},
@@ -4203,6 +4234,7 @@ files = [
     {file = "stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695"},
     {file = "stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [package.dependencies]
 asttokens = ">=2.1.0"
@@ -4268,9 +4300,10 @@ docs = ["ipykernel", "jupyter-client", "matplotlib", "nbconvert", "nbformat", "n
 name = "tabulate"
 version = "0.9.0"
 description = "Pretty-print tabular data"
-optional = false
+optional = true
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "extra == \"summary\""
 files = [
     {file = "tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f"},
     {file = "tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c"},
@@ -4353,6 +4386,7 @@ files = [
     {file = "tornado-6.5.1-cp39-abi3-win_arm64.whl", hash = "sha256:02420a0eb7bf617257b9935e2b754d1b63897525d8a289c9d65690d580b4dcf7"},
     {file = "tornado-6.5.1.tar.gz", hash = "sha256:84ceece391e8eb9b2b95578db65e920d2a61070260594819589609ba9bc6308c"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [[package]]
 name = "tqdm"
@@ -4387,6 +4421,7 @@ files = [
     {file = "traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f"},
     {file = "traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [package.extras]
 docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
@@ -4536,6 +4571,7 @@ files = [
     {file = "wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859"},
     {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
 ]
+markers = {main = "extra == \"parallel\""}
 
 [[package]]
 name = "webcolors"
@@ -4606,7 +4642,13 @@ files = [
 [package.extras]
 dev = ["black (>=19.3b0) ; python_version >= \"3.6\"", "pytest (>=4.6.2)"]
 
+[extras]
+optimize = ["optuna"]
+parallel = ["ipyparallel"]
+summary = ["tabulate"]
+visual = ["plotly", "seaborn"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "ce68268ccd858a3d837c021a8d3cf9b55e7a033410f1db3338a8b1f6bfce5e5f"
+content-hash = "b46c146dfaf7e858dbacbe96c7d6daee3e9ec5cc0895c8644ba4700ae81b5a3f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,18 +18,18 @@ numpy = "^2.2.6"
 pandas = "^2.2.3"
 scipy = "^1.15.3"
 matplotlib = "^3.10.3"
-seaborn = "^0.13.2"
-plotly = "^6.1.2"
+seaborn = {version = "^0.13.2", optional = true}
+plotly = {version = "^6.1.2", optional = true}
 scikit-learn = "^1.6.1"
 tqdm = "^4.67.1"
 joblib = "^1.5.1"
-ipyparallel = "^9.0.1"
+ipyparallel = {version = "^9.0.1", optional = true}
 requests = "^2.32.3"
 loguru = "^0.7.3"
 networkx = "^3.5"
 jsonpickle = "^4.1.1"
 statsmodels = "^0.14.4"
-tabulate = "^0.9.0"
+tabulate = {version = "^0.9.0", optional = true}
 intervaltree = "^3.1.0"
 events = "^0.5"
 pymzml = "^2.5.11"
@@ -38,7 +38,13 @@ mass-spec-utils = "^0.0.12"
 pysmiles = "^2.0.0"
 numba = "^0.61.2"
 numba-stats = "^1.10.1"
-optuna = "^4.3.0"
+optuna = {version = "^4.3.0", optional = true}
+
+[tool.poetry.extras]
+visual = ["plotly", "seaborn"]
+parallel = ["ipyparallel"]
+optimize = ["optuna"]
+summary = ["tabulate"]
 
 [tool.poetry.group.dev.dependencies]
 jupyterlab = "^4.4.3"

--- a/vimms/BoxVisualise.py
+++ b/vimms/BoxVisualise.py
@@ -12,10 +12,19 @@ import numpy as np
 from PIL import ImageColor
 import matplotlib.patches as patches
 import matplotlib.pyplot as plt
-import seaborn as sns
-import plotly.graph_objects as go
-from plotly.subplots import make_subplots
-from plotly.colors import DEFAULT_PLOTLY_COLORS
+try:
+    import seaborn as sns
+except ImportError:  # pragma: no cover - optional dependency
+    sns = None
+
+try:
+    import plotly.graph_objects as go
+    from plotly.subplots import make_subplots
+    from plotly.colors import DEFAULT_PLOTLY_COLORS
+except ImportError:  # pragma: no cover - optional dependency
+    go = None
+    make_subplots = None
+    DEFAULT_PLOTLY_COLORS = None
 
 from vimms.Common import path_or_mzml, get_scan_times_combined, get_scan_times
 from vimms.Box import GenericBox, BoxGrid
@@ -395,6 +404,9 @@ class PlotPoints:
         abs_scaling=False,
     ):
 
+        if go is None:
+            raise ImportError("plotly is required for plotly_ms1s; install vimms[visual]")
+
         self.points_in_bounds(min_rt=min_rt, max_rt=max_rt, min_mz=min_mz, max_mz=max_mz)
         if np.sum(self.active_ms1) == 0:
             return
@@ -450,6 +462,9 @@ class PlotPoints:
         colour_minm=None,
         abs_scaling=False,
     ):
+
+        if go is None:
+            raise ImportError("plotly is required for plotly_ms2s; install vimms[visual]")
 
         self.points_in_bounds(min_rt=min_rt, max_rt=max_rt, min_mz=min_mz, max_mz=max_mz)
         if np.sum(self.active_ms2) == 0:
@@ -898,6 +913,10 @@ def mpl_fragmented_boxes(exp_name, eva, mode="max", min_intensity=0.0):
 
 
 def plotly_results_plot(experiment_names, evals, min_intensity=0.0, suptitle=None):
+    if go is None:
+        raise ImportError(
+            "plotly is required for plotly_results_plot; install vimms[visual]"
+        )
     num_chems = len(evals[0].chems)
     results = [eva.evaluation_report(min_intensity=min_intensity) for eva in evals]
     repeat = max(r["num_runs"] for r in results)
@@ -962,6 +981,8 @@ def plotly_results_plot(experiment_names, evals, min_intensity=0.0, suptitle=Non
 
 
 def plotly_mzml(mzml, draw_minm=0.0, colour_minm=None, show_precursors=False):
+    if go is None:
+        raise ImportError("plotly is required for plotly_mzml; install vimms[visual]")
     fig = go.Figure()
 
     mzml = path_or_mzml(mzml)
@@ -983,6 +1004,10 @@ def plotly_mzml(mzml, draw_minm=0.0, colour_minm=None, show_precursors=False):
 
 
 def plotly_timing_hist(processing_times, title, binsize=None):
+    if go is None:
+        raise ImportError(
+            "plotly is required for plotly_timing_hist; install vimms[visual]"
+        )
     fig = make_subplots(rows=1, cols=len(processing_times))
 
     for i, run_times in enumerate(processing_times):
@@ -1007,6 +1032,10 @@ def plotly_timing_hist(processing_times, title, binsize=None):
 
 
 def plotly_fragmentation_events(exp_name, mzmls, colour_minm=None):
+    if go is None:
+        raise ImportError(
+            "plotly is required for plotly_fragmentation_events; install vimms[visual]"
+        )
     fig = make_subplots(rows=len(mzmls), cols=1, shared_xaxes="all", shared_yaxes="all")
 
     for i, mzml in enumerate(mzmls):
@@ -1026,6 +1055,10 @@ def plotly_fragmentation_events(exp_name, mzmls, colour_minm=None):
 
 
 def seaborn_hist(data, xlabel, binsize=None):
+    if sns is None:
+        raise ImportError(
+            "seaborn is required for seaborn_hist; install vimms[visual]"
+        )
     fig, axes = plt.subplots(1, len(data), figsize=(15, 5), sharey=True)
 
     try:
@@ -1041,6 +1074,10 @@ def seaborn_hist(data, xlabel, binsize=None):
 
 
 def seaborn_mzml_timing_hist(mzmls, binsize=None, mode="combined"):
+    if sns is None:
+        raise ImportError(
+            "seaborn is required for seaborn_mzml_timing_hist; install vimms[visual]"
+        )
     if mode == "combined":
         timings = [get_scan_times_combined(mzmls)]
     else:
@@ -1072,10 +1109,18 @@ def seaborn_mzml_timing_hist(mzmls, binsize=None, mode="combined"):
 
 
 def seaborn_timing_hist(processing_times, binsize=None):
+    if sns is None:
+        raise ImportError(
+            "seaborn is required for seaborn_timing_hist; install vimms[visual]"
+        )
     return seaborn_hist(processing_times, xlabel="Processing time (secs)", binsize=binsize)
 
 
 def seaborn_uncovered_area_hist(eva, box_likes, min_intensity=0.0, cumulative=False, binsize=None):
+    if sns is None:
+        raise ImportError(
+            "seaborn is required for seaborn_uncovered_area_hist; install vimms[visual]"
+        )
 
     boxes = [[b.to_box(0, 0) for b in ls] for ls in box_likes]
     geom = BoxGrid()

--- a/vimms/InSilicoSimulation.py
+++ b/vimms/InSilicoSimulation.py
@@ -5,7 +5,10 @@ import json
 import os
 from pathlib import Path
 
-import ipyparallel as ipp
+try:
+    import ipyparallel as ipp
+except ImportError:  # pragma: no cover - optional dependency
+    ipp = None
 import matplotlib.pyplot as plt
 import numpy as np
 from loguru import logger
@@ -181,14 +184,14 @@ def run_SmartROI(chems, scan_duration, params, out_dir):
     logger.warning("Running controllers in parallel, please wait ...")
     run_serial = False
     try:
+        if ipp is None:
+            raise ImportError
         rc = ipp.Client()
         dview = rc[:]  # use all engines
         with dview.sync_imports():
             pass
         dview.map_sync(run_single_SmartROI, params_list)
-    except OSError:  # cluster has not been started
-        run_serial = True
-    except ipp.error.TimeoutError:  # takes too long to run
+    except Exception:
         run_serial = True
 
     if run_serial:  # if any exception from above, try to run it serially
@@ -271,17 +274,16 @@ def run_WeightedDEW(chems, scan_duration, params, out_dir):
 
     # Try to run the controllers in parallel. If fails, then run it serially
     logger.warning("Running controllers in parallel, please wait ...")
+    run_serial = False
     try:
-        import ipyparallel as ipp
-
+        if ipp is None:
+            raise ImportError
         rc = ipp.Client()
         dview = rc[:]  # use all engines
         with dview.sync_imports():
             pass
         dview.map_sync(run_single_WeightedDEW, params_list)
-    except OSError:  # cluster has not been started
-        run_serial = True
-    except ipp.error.TimeoutError:  # takes too long to run
+    except Exception:
         run_serial = True
 
     if run_serial:  # if any exception from above, try to run it serially


### PR DESCRIPTION
## Summary
- mark rarely used libraries as optional dependencies via extras
- defer `seaborn`, `plotly` and `ipyparallel` imports to runtime
- handle missing optional libraries in visualisation modules
- regenerate poetry.lock

## Testing
- `poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude .venv`
- `poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude .venv`
- `poetry run pytest tests/test_box_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6849446f98b483269c8f8ed960e80911