### PR TITLE
Write precursor isolation window to mzML

### DIFF
--- a/tests/test_controllers_TopN.py
+++ b/tests/test_controllers_TopN.py
@@ -575,3 +575,53 @@ class TestWeightedDEWController:
         # write simulated output to mzML file
         filename = "topN_weighted_dew_controller_qcbeer_chems_no_noise.mzML"
         check_mzML(env, OUT_DIR, filename)
+
+
+class TestTopNIsolationWindow:
+    """
+    The written mzML must carry the precursor <isolationWindow> (target m/z plus
+    lower/upper offsets), not only the selected-ion m/z, so that downstream tools
+    can recover the precursor isolation range. Regression test for the previously
+    missing isolation window.
+    """
+
+    def test_isolation_window_written(self, even_chems):
+        import xml.etree.ElementTree as ET
+
+        isolation_width = 2.0  # distinctive width -> offsets must be 1.0
+        N = 10
+        mass_spec = IndependentMassSpectrometer(POSITIVE, even_chems)
+        controller = TopNController(
+            POSITIVE, N, isolation_width, 10, 15, 0, force_N=True
+        )
+        env = Environment(mass_spec, controller, 200, 300, progress_bar=False)
+        run_environment(env)
+
+        filename = "topn_isolation_window.mzML"
+        check_mzML(env, OUT_DIR, filename)
+
+        NS = "{http://psi.hupo.org/ms/mzml}"
+
+        def cvparams(el):
+            return {c.get("accession"): c.get("value") for c in el.findall(NS + "cvParam")}
+
+        tree = ET.parse(os.path.join(OUT_DIR, filename))
+        n_ms2 = 0
+        for spec in tree.iter(NS + "spectrum"):
+            if cvparams(spec).get("MS:1000511") != "2":  # ms level
+                continue
+            n_ms2 += 1
+            precursor = spec.find(".//" + NS + "precursor")
+            window = precursor.find(NS + "isolationWindow")
+            assert window is not None, "MS2 precursor is missing an isolationWindow"
+            wp = cvparams(window)
+            target = float(wp["MS:1000827"])  # isolation window target m/z
+            lower = float(wp["MS:1000828"])   # isolation window lower offset
+            upper = float(wp["MS:1000829"])   # isolation window upper offset
+            sel = cvparams(precursor.find(".//" + NS + "selectedIon"))
+            selected_mz = float(sel["MS:1000744"])  # selected ion m/z
+            assert target == selected_mz                 # window centred on precursor
+            assert lower == isolation_width / 2.0        # offsets are half the width
+            assert upper == isolation_width / 2.0
+
+        assert n_ms2 > 0, "no MS2 scans were written"

--- a/vimms/MzmlWriter.py
+++ b/vimms/MzmlWriter.py
@@ -182,17 +182,38 @@ class MzmlWriter:
             collision_energy = scan.scan_params.get(ScanParameters.COLLISION_ENERGY)
             activation_type = scan.scan_params.get(ScanParameters.ACTIVATION_TYPE)
 
+            isolation_widths = scan.scan_params.get(ScanParameters.ISOLATION_WIDTH)
+
             precursor_information = []
-            for precursor in scan.scan_params.get(ScanParameters.PRECURSOR_MZ):
-                precursor_information.append(
-                    {
-                        "mz": precursor.precursor_mz,
-                        "intensity": precursor.precursor_intensity,
-                        "charge": precursor.precursor_charge,
-                        "spectrum_reference": precursor.precursor_scan_id,
-                        "activation": [activation_type, {"collision energy": collision_energy}],
+            for i, precursor in enumerate(scan.scan_params.get(ScanParameters.PRECURSOR_MZ)):
+                info = {
+                    "mz": precursor.precursor_mz,
+                    "intensity": precursor.precursor_intensity,
+                    "charge": precursor.precursor_charge,
+                    "spectrum_reference": precursor.precursor_scan_id,
+                    "activation": [activation_type, {"collision energy": collision_energy}],
+                }
+
+                # Emit the precursor isolation window so that downstream mzML
+                # consumers can recover the isolation range, not just the centre
+                # m/z. psims accepts {"lower", "target", "upper"} where lower/upper
+                # are the m/z offsets from the target. The isolation width is the
+                # one passed to the controller (ScanParameters.ISOLATION_WIDTH).
+                width = None
+                if isinstance(isolation_widths, (list, tuple, np.ndarray)):
+                    if i < len(isolation_widths):
+                        width = isolation_widths[i]
+                elif isolation_widths is not None:
+                    width = isolation_widths
+                if width is not None:
+                    half_width = width / 2.0
+                    info["isolation_window"] = {
+                        "lower": half_width,
+                        "target": precursor.precursor_mz,
+                        "upper": half_width,
                     }
-                )
+
+                precursor_information.append(info)
 
         lowest_observed_mz = min(scan.mzs)
         highest_observed_mz = max(scan.mzs)


### PR DESCRIPTION
MzmlWriter emitted the selected-ion m/z, activation type, and collision energy for each MS2 precursor, but never an <isolationWindow> element, so the isolation range was lost on export even though it is already available as ScanParameters.ISOLATION_WIDTH. Downstream mzML consumers could recover only the precursor centre m/z, not the window.

Emit the isolation window per precursor in MzmlWriter._write_scan, reusing psims' precursor isolation_window support: target m/z = precursor m/z and lower/upper offsets = half the controller isolation width. The change is guarded so scans without an isolation width are written unchanged.

Add a regression test (TestTopNIsolationWindow) asserting every MS2 scan in the written mzML carries an isolationWindow centred on its precursor with lower/upper offsets equal to half the isolation width.