### PR TITLE
Close mzML output handle explicitly

### DIFF
--- a/tests/test_mzml_writer.py
+++ b/tests/test_mzml_writer.py
@@ -1,0 +1,69 @@
+import vimms.MzmlWriter as mzml_writer_module
+from vimms.MzmlWriter import MzmlWriter
+
+
+class _ContextManager:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+
+class _FakePsimsMzMLWriter:
+    opened_handles = []
+
+    def __init__(self, out_handle):
+        self.opened_handles.append(out_handle)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def controlled_vocabularies(self):
+        pass
+
+    def file_description(self, *args, **kwargs):
+        pass
+
+    def sample_list(self, *args, **kwargs):
+        pass
+
+    def software_list(self, *args, **kwargs):
+        pass
+
+    def scan_settings_list(self, *args, **kwargs):
+        pass
+
+    def instrument_configuration_list(self, *args, **kwargs):
+        pass
+
+    def data_processing_list(self, *args, **kwargs):
+        pass
+
+    def run(self, *args, **kwargs):
+        return _ContextManager()
+
+    def spectrum_list(self, *args, **kwargs):
+        return _ContextManager()
+
+    def chromatogram_list(self, *args, **kwargs):
+        return _ContextManager()
+
+    def write_chromatogram(self, *args, **kwargs):
+        pass
+
+    def close(self):
+        pass
+
+
+def test_mzml_writer_closes_output_handle(monkeypatch, tmp_path):
+    _FakePsimsMzMLWriter.opened_handles = []
+    monkeypatch.setattr(mzml_writer_module, "PsimsMzMLWriter", _FakePsimsMzMLWriter)
+
+    MzmlWriter("test_analysis", {1: []}).write_mzML(tmp_path / "test.mzML")
+
+    assert len(_FakePsimsMzMLWriter.opened_handles) == 1
+    assert _FakePsimsMzMLWriter.opened_handles[0].closed

--- a/vimms/MzmlWriter.py
+++ b/vimms/MzmlWriter.py
@@ -50,29 +50,28 @@ class MzmlWriter:
         create_if_not_exist(out_dir)
 
         # start writing mzML here
-        with PsimsMzMLWriter(open(out_file, "wb")) as writer:
-            # add default controlled vocabularies
-            writer.controlled_vocabularies()
+        with open(out_file, "wb") as out_handle:
+            with PsimsMzMLWriter(out_handle) as writer:
+                # add default controlled vocabularies
+                writer.controlled_vocabularies()
 
-            # write other fields like sample list, software list, etc.
-            self._write_info(writer)
+                # write other fields like sample list, software list, etc.
+                self._write_info(writer)
 
-            # open the run
-            with writer.run(id=self.analysis_name):
-                self._write_spectra(writer, self.scans)
+                # open the run
+                with writer.run(id=self.analysis_name):
+                    self._write_spectra(writer, self.scans)
 
-                # open chromatogram list sections
-                with writer.chromatogram_list(count=1):
-                    tic_rts, tic_intensities = self._get_tic_chromatogram(self.scans)
-                    writer.write_chromatogram(
-                        tic_rts,
-                        tic_intensities,
-                        id="tic",
-                        chromatogram_type="total ion current chromatogram",
-                        time_unit="second",
-                    )
-
-        writer.close()
+                    # open chromatogram list sections
+                    with writer.chromatogram_list(count=1):
+                        tic_rts, tic_intensities = self._get_tic_chromatogram(self.scans)
+                        writer.write_chromatogram(
+                            tic_rts,
+                            tic_intensities,
+                            id="tic",
+                            chromatogram_type="total ion current chromatogram",
+                            time_unit="second",
+                        )
 
     def _write_info(self, out):
         """


### PR DESCRIPTION
## Summary

Make `MzmlWriter.write_mzML()` explicitly own the binary output file handle with a Python `with open(...)` context before passing it to psims.

This is a defensive fix for #222. I could not reproduce the file-lock behavior on macOS, but the original issue appears Windows/notebook-specific. The previous code created the file handle inline inside `PsimsMzMLWriter(open(out_file, "wb"))`, which made handle ownership depend on psims internals. The new code guarantees the handle ViMMS opens is closed when `write_mzML()` returns.

## Changes

- Wrap mzML output in `with open(out_file, "wb") as out_handle:`.
- Remove the redundant explicit `writer.close()` after the psims context manager.
- Add a regression test with a fake psims writer that does not close the handle, asserting ViMMS still closes it.

## Validation

- `pytest -q tests/test_mzml_writer.py tests/test_controllers_fullscan.py tests/test_controllers_TopN.py` -> `19 passed`
- `git diff --check HEAD~1..HEAD` -> clean

Fixes #222.