### PR TITLE
Allow low-m/z MS2 product ions

### DIFF
--- a/tests/test_controllers_TopN.py
+++ b/tests/test_controllers_TopN.py
@@ -19,13 +19,21 @@ from tests.conftest import (
 )
 from vimms.ChemicalSamplers import (
     EvenMZFormulaSampler,
+    UniformMZFormulaSampler,
     FixedMS2Sampler,
     UniformRTAndIntensitySampler,
     ConstantChromatogramSampler,
     DatabaseFormulaSampler,
 )
 from vimms.Chemicals import ChemicalMixtureCreator
-from vimms.Common import POSITIVE, set_log_level_warning, NEGATIVE, ScanParameters
+from vimms.Common import (
+    ADDUCT_DICT_POS_MH,
+    DUMMY_PRECURSOR_MZ,
+    POSITIVE,
+    set_log_level_warning,
+    NEGATIVE,
+    ScanParameters,
+)
 from vimms.Controller import (
     TopNController,
     SimpleMs1Controller,
@@ -35,6 +43,48 @@ from vimms.Controller import (
 from vimms.Environment import Environment
 from vimms.MassSpec import IndependentMassSpectrometer
 from vimms.Noise import GaussianPeakNoise
+
+
+def make_low_mz_fixed_ms2_dataset():
+    fs = UniformMZFormulaSampler(min_mz=75, max_mz=75)
+    ms = FixedMS2Sampler(n_frags=2)
+    ri = UniformRTAndIntensitySampler(min_rt=100, max_rt=101)
+    cs = ConstantChromatogramSampler()
+    cm = ChemicalMixtureCreator(
+        fs,
+        ms2_sampler=ms,
+        rt_and_intensity_sampler=ri,
+        chromatogram_sampler=cs,
+        adduct_prior_dict=ADDUCT_DICT_POS_MH,
+        adduct_proportion_cutoff=0.0,
+    )
+    return cm.sample(1, 2)
+
+
+def run_low_mz_topn(advanced_params=None):
+    dataset = make_low_mz_fixed_ms2_dataset()
+    mass_spec = IndependentMassSpectrometer(POSITIVE, dataset)
+    controller = TopNController(
+        POSITIVE,
+        1,
+        0.7,
+        10,
+        15,
+        0,
+        advanced_params=advanced_params,
+        force_N=True,
+    )
+    env = Environment(mass_spec, controller, 100, 103, progress_bar=False)
+    run_environment(env)
+    return mass_spec, controller
+
+
+def get_real_ms2_scan(controller):
+    for scan in controller.scans[2]:
+        precursor_list = scan.scan_params.get(ScanParameters.PRECURSOR_MZ)
+        if precursor_list[0].precursor_mz != DUMMY_PRECURSOR_MZ:
+            return scan
+    raise AssertionError("Expected at least one non-dummy MS2 scan")
 
 
 class TestNegative:
@@ -223,6 +273,7 @@ class TestTopNAdvanced:
         # set some values that are not the defaults, so we know they're passed correctly
         params = AdvancedParams(
             default_ms1_scan_window=(10.0, 2000.0),
+            default_ms2_scan_window=(50.0, 500.0),
             ms1_agc_target=100000,
             ms1_max_it=500,
             ms1_collision_energy=200,
@@ -285,6 +336,8 @@ class TestTopNAdvanced:
         # ms2 check
         scan = controller.scans[2][0]
         scan_params = scan.scan_params
+        assert scan_params.get(ScanParameters.FIRST_MASS) == params.default_ms2_scan_window[0]
+        assert scan_params.get(ScanParameters.LAST_MASS) == params.default_ms2_scan_window[1]
         assert scan_params.get(ScanParameters.AGC_TARGET) == params.ms2_agc_target
         assert scan_params.get(ScanParameters.MAX_IT) == params.ms2_max_it
         assert scan_params.get(ScanParameters.COLLISION_ENERGY) == params.ms2_collision_energy
@@ -295,6 +348,28 @@ class TestTopNAdvanced:
         assert scan_params.get(ScanParameters.MASS_ANALYSER) == params.ms2_mass_analyser
         assert scan_params.get(ScanParameters.ISOLATION_MODE) == params.ms2_isolation_mode
         assert scan_params.get(ScanParameters.SOURCE_CID_ENERGY) == params.ms2_source_cid_energy
+
+
+class TestTopNMS2ScanWindow:
+    def test_default_ms2_scan_window_allows_low_mz_product_ions(self):
+        mass_spec, controller = run_low_mz_topn()
+
+        scan = get_real_ms2_scan(controller)
+        scan_params = scan.scan_params
+        assert scan_params.get(ScanParameters.FIRST_MASS) == 0.0
+        assert scan.num_peaks == 2
+        assert all(mz < 70 for mz in scan.mzs)
+        assert any(event.precursor_mz for event in mass_spec.fragmentation_events)
+
+    def test_advanced_ms2_scan_window_can_restore_low_mz_cutoff(self):
+        params = AdvancedParams(default_ms2_scan_window=(70.0, None))
+        mass_spec, controller = run_low_mz_topn(advanced_params=params)
+
+        scan = get_real_ms2_scan(controller)
+        scan_params = scan.scan_params
+        assert scan_params.get(ScanParameters.FIRST_MASS) == 70.0
+        assert scan.num_peaks == 0
+        assert not any(event.precursor_mz for event in mass_spec.fragmentation_events)
 
 
 class TestIonisationMode:

--- a/vimms/Common.py
+++ b/vimms/Common.py
@@ -48,7 +48,7 @@ SCAN_DURATION = "scan_duration"
 POSITIVE = "Positive"
 NEGATIVE = "Negative"
 DEFAULT_MS1_SCAN_WINDOW = (70.0, 1000.0)
-DEFAULT_MSN_SCAN_WINDOW = (70.0, 600.0)
+DEFAULT_MSN_SCAN_WINDOW = (0.0, None)
 DEFAULT_ISOLATION_WIDTH = 0.7
 CHEM_DATA = "data"
 CHEM_NOISE = "noise"
@@ -848,6 +848,7 @@ def get_dda_scan_param(
     polarity=POSITIVE,
     metadata=None,
     scan_id=None,
+    default_ms2_scan_window=DEFAULT_MSN_SCAN_WINDOW,
 ):
     """
     Generate the default MS2 scan parameters.
@@ -870,6 +871,9 @@ def get_dda_scan_param(
         polarity: the polarity value, either POSITIVE or NEGATIVE
         metadata: additional metadata to include in this scan
         scan_id: the scan ID, if specified
+        default_ms2_scan_window: the MS2 product-ion m/z window. If the upper
+                                 bound is None, it is scaled dynamically from
+                                 the precursor m/z.
 
     Returns: the parameters of the MS2 scan to create
 
@@ -879,6 +883,11 @@ def get_dda_scan_param(
     dda_scan_params.set(ScanParameters.MS_LEVEL, 2)
 
     assert isinstance(mz, list) == isinstance(intensity, list)
+    assert len(default_ms2_scan_window) == 2
+    first_mass, configured_last_mass = default_ms2_scan_window
+    assert first_mass is not None
+    if configured_last_mass is not None:
+        assert configured_last_mass >= first_mass
 
     # create precursor object, assume it's all singly charged
     precursor_charge = +1 if (polarity == POSITIVE) else -1
@@ -931,7 +940,7 @@ def get_dda_scan_param(
     dda_scan_params.set(ScanParameters.MAX_IT, max_it)
     dda_scan_params.set(ScanParameters.SOURCE_CID_ENERGY, source_cid_energy)
     dda_scan_params.set(ScanParameters.POLARITY, polarity)
-    dda_scan_params.set(ScanParameters.FIRST_MASS, DEFAULT_MSN_SCAN_WINDOW[0])
+    dda_scan_params.set(ScanParameters.FIRST_MASS, first_mass)
     dda_scan_params.set(ScanParameters.METADATA, metadata)
     dda_scan_params.set(ScanParameters.SCAN_ID, scan_id)
 
@@ -941,6 +950,7 @@ def get_dda_scan_param(
     max_precursor_mz = max(
         [(p.precursor_mz + isol / 2) for (p, isol) in zip(precursor_list, isolation_width)]
     )
-    last_mass = max_precursor_mz * charge * wiggle_room
+    dynamic_last_mass = max_precursor_mz * charge * wiggle_room
+    last_mass = dynamic_last_mass if configured_last_mass is None else configured_last_mass
     dda_scan_params.set(ScanParameters.LAST_MASS, last_mass)
     return dda_scan_params

--- a/vimms/Controller/base.py
+++ b/vimms/Controller/base.py
@@ -11,6 +11,7 @@ import pandas as pd
 
 from vimms.Common import (
     DEFAULT_MS1_SCAN_WINDOW,
+    DEFAULT_MSN_SCAN_WINDOW,
     DEFAULT_MS1_AGC_TARGET,
     DEFAULT_MS1_MAXIT,
     DEFAULT_MS1_COLLISION_ENERGY,
@@ -65,6 +66,7 @@ class AdvancedParams:
         ms2_mass_analyser=DEFAULT_MS2_MASS_ANALYSER,
         ms2_isolation_mode=DEFAULT_MS2_ISOLATION_MODE,
         ms2_source_cid_energy=DEFAULT_SOURCE_CID_ENERGY,
+        default_ms2_scan_window=DEFAULT_MSN_SCAN_WINDOW,
     ):
         """
         Create an advanced parameter object
@@ -87,8 +89,10 @@ class AdvancedParams:
             ms2_mass_analyser: the mass analyser to use for MS2 scan, either IonTrap or Orbitrap
             ms2_isolation_mode: the isolation mode for MS2 scan, either None, Quadrupole, IonTrap
             ms2_source_cid_energy: source CID energy
+            default_ms2_scan_window: the product-ion m/z window to perform MS2 scan
         """
         self.default_ms1_scan_window = default_ms1_scan_window
+        self.default_ms2_scan_window = default_ms2_scan_window
 
         self.ms1_agc_target = ms1_agc_target
         self.ms1_max_it = ms1_max_it
@@ -203,6 +207,7 @@ class Controller(ABC):
             isolation_mode=self.advanced_params.ms2_isolation_mode,
             polarity=self.environment.mass_spec.ionisation_mode,
             metadata=metadata,
+            default_ms2_scan_window=self.advanced_params.default_ms2_scan_window,
         )
         return task
 


### PR DESCRIPTION
## Original issue

Issue #257 reports that low-m/z targets around the 80 m/z boundary do not appear to fragment correctly. Reproducing it showed that the controller can select a low precursor, but the generated MS2 product ions are then filtered out by the hard-coded MSn product-ion scan lower bound of 70 m/z.

For example, a precursor around 76 m/z produces fixed fragments around 56 and 66 m/z. With the current default lower bound of 70, both fragments are discarded, leaving an empty MS2 scan and no useful fragmentation event. Around 80 m/z, one fragment reaches the 70 m/z boundary, which explains the observed threshold-like behavior.

## Fix plan

This PR changes the default MS2 product-ion scan range to have no artificial lower bound while keeping the existing dynamic upper-bound behavior:

- set `DEFAULT_MSN_SCAN_WINDOW` to `(0.0, None)`
- interpret `None` as "compute the upper mass dynamically from the precursor", matching the previous default behavior
- expose `AdvancedParams(default_ms2_scan_window=...)` so users can restore or customize the product-ion range, e.g. `(70.0, None)` or `(50.0, 500.0)`
- pass the setting through `Controller.get_ms2_scan_params()` into `get_dda_scan_param()`
- add TopN regression tests for the low-m/z case and for restoring the old cutoff explicitly

## Validation

Ran with the `vimms` conda environment:

- `pytest -q tests/test_controllers_TopN.py`
- `pytest -q tests/test_controllers_misc.py tests/test_chemical_generation.py::TestChemicalsFromMZML::test_topn_from_mzml tests/test_additional_modules.py`
- `pytest -q tests/test_chemical_generation.py`
- `git diff --check`